### PR TITLE
feat(pricing): filter ratio table to only active-channel models

### DIFF
--- a/web/default/src/features/system-settings/models/model-ratio-visual-editor.tsx
+++ b/web/default/src/features/system-settings/models/model-ratio-visual-editor.tsx
@@ -11,9 +11,12 @@ import {
   getPaginationRowModel,
   useReactTable,
 } from '@tanstack/react-table'
+import { useQuery } from '@tanstack/react-query'
 import { Pencil, Plus, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 import {
   Table,
   TableBody,
@@ -28,6 +31,7 @@ import {
   DataTablePagination,
 } from '@/components/data-table'
 import { StatusBadge } from '@/components/status-badge'
+import { getEnabledModels } from '@/features/channels/api'
 import {
   combineBillingExpr,
   splitBillingExprAndRequestRules,
@@ -66,6 +70,7 @@ type ModelRow = {
 }
 
 const STORAGE_KEY = 'model-ratio-column-visibility'
+const ACTIVE_FILTER_STORAGE_KEY = 'model-ratio-only-active-channels'
 
 const formatValue = (value?: string) => {
   if (!value || value === '') return '—'
@@ -131,6 +136,33 @@ export const ModelRatioVisualEditor = memo(
     useEffect(() => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(columnVisibility))
     }, [columnVisibility])
+
+    // Toggle: only show models that are bound to at least one enabled channel.
+    // Default ON for less-cluttered admin view; admins who add new chat models
+    // can flip it off briefly to see (and edit) all configured pricing rows.
+    const [onlyActiveChannels, setOnlyActiveChannels] = useState<boolean>(
+      () => localStorage.getItem(ACTIVE_FILTER_STORAGE_KEY) !== 'false'
+    )
+    useEffect(() => {
+      localStorage.setItem(
+        ACTIVE_FILTER_STORAGE_KEY,
+        onlyActiveChannels ? 'true' : 'false'
+      )
+    }, [onlyActiveChannels])
+
+    // Active-channel models come from `abilities` (distinct model name across
+    // every enabled channel). Querying lazily so the table still works even
+    // if the endpoint errors — see the resolved `enabledModelSet` below.
+    const { data: enabledModelsData, isLoading: enabledLoading } = useQuery({
+      queryKey: ['channel', 'models_enabled'],
+      queryFn: getEnabledModels,
+      staleTime: 60_000,
+      enabled: onlyActiveChannels,
+    })
+    const enabledModelSet = useMemo(
+      () => new Set(enabledModelsData?.data || []),
+      [enabledModelsData]
+    )
 
     const models = useMemo(() => {
       const priceMap = safeJsonParse<Record<string, number>>(modelPrice, {
@@ -251,7 +283,13 @@ export const ModelRatioVisualEditor = memo(
         }
       })
 
-      return modelData.sort((a, b) => a.name.localeCompare(b.name))
+      const sorted = modelData.sort((a, b) => a.name.localeCompare(b.name))
+      // Apply active-channel filter LAST so the underlying pricing data is
+      // never lost — saves still operate on the full maps in handleSave.
+      if (onlyActiveChannels && !enabledLoading && enabledModelSet.size > 0) {
+        return sorted.filter((row) => enabledModelSet.has(row.name))
+      }
+      return sorted
     }, [
       modelPrice,
       modelRatio,
@@ -263,6 +301,9 @@ export const ModelRatioVisualEditor = memo(
       audioCompletionRatio,
       billingMode,
       billingExpr,
+      onlyActiveChannels,
+      enabledLoading,
+      enabledModelSet,
     ])
 
     const handleEdit = useCallback((model: ModelRow) => {
@@ -700,11 +741,29 @@ export const ModelRatioVisualEditor = memo(
 
     return (
       <div className='space-y-4'>
-        <div className='flex items-center justify-between gap-4'>
-          <DataTableToolbar
-            table={table}
-            searchPlaceholder={t('Search models...')}
-          />
+        <div className='flex flex-wrap items-center justify-between gap-4'>
+          <div className='flex flex-wrap items-center gap-4'>
+            <DataTableToolbar
+              table={table}
+              searchPlaceholder={t('Search models...')}
+            />
+            <div className='flex items-center gap-2'>
+              <Switch
+                id='only-active-channels'
+                checked={onlyActiveChannels}
+                onCheckedChange={setOnlyActiveChannels}
+              />
+              <Label
+                htmlFor='only-active-channels'
+                className='cursor-pointer text-sm font-normal'
+                title={t(
+                  'Hide rows for models that are not bound to any enabled channel. Pricing data is preserved — toggle off to edit.'
+                )}
+              >
+                {t('Only active channels')}
+              </Label>
+            </div>
+          </div>
           <Button onClick={handleAdd}>
             <Plus className='mr-2 h-4 w-4' />
             {t('Add model')}
@@ -715,7 +774,11 @@ export const ModelRatioVisualEditor = memo(
           <div className='text-muted-foreground rounded-lg border border-dashed p-8 text-center'>
             {table.getState().globalFilter
               ? t('No models match your search')
-              : t('No models configured. Click "Add model" to get started.')}
+              : onlyActiveChannels
+                ? t(
+                    'No priced models are bound to an enabled channel. Toggle off "Only active channels" to see all configured pricing.'
+                  )
+                : t('No models configured. Click "Add model" to get started.')}
           </div>
         ) : (
           <div className='overflow-hidden rounded-md border'>

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -4373,6 +4373,9 @@
     "Pinning the spec via the model id": "用模型 ID 后缀锁规格",
     "Source:": "出处：",
     "Full list:": "完整列表：",
-    "Pixverse": "Pixverse"
+    "Pixverse": "Pixverse",
+    "Only active channels": "仅显示已启用渠道的模型",
+    "Hide rows for models that are not bound to any enabled channel. Pricing data is preserved — toggle off to edit.": "隐藏未绑定任何启用渠道的模型。价格数据仍保留——关闭开关即可编辑。",
+    "No priced models are bound to an enabled channel. Toggle off \"Only active channels\" to see all configured pricing.": "暂无已定价且绑定启用渠道的模型。关闭「仅显示已启用渠道的模型」可查看全部定价配置。"
   }
 }


### PR DESCRIPTION
## Summary

Pricing Ratios → Model Ratios table previously showed every model that ever had a ratio default in upstream new-api (4000+ rows of `360gpt-*`, `ada`, `babbage`, etc. that have no channels in this fork). Adding a Pixverse SKU was painful — admins had to wade through pages of unrelated defaults.

This PR adds a **"仅显示已启用渠道的模型 / Only active channels"** toggle next to the search box. Default ON, persisted in localStorage. The filter is purely cosmetic — pricing JSON is untouched, so toggling OFF gets the full list back instantly.

## Behavior

| State | Shows |
|---|---|
| **ON** (default) | Models that appear in `abilities` for an enabled channel — i.e. the rows you can actually deduct from |
| **OFF** | Every priced model, same as today |

## Why a toggle, not a wipe

Earlier conversation considered deleting the unused ratio entries entirely. That's destructive — once gone, adding a chat channel later means re-configuring every model's ratio from scratch. A view-only filter gives the same clean UX with zero data loss and a one-click escape hatch.

## Screenshots

| ON (default) | OFF |
|---|---|
| Pixverse + Seedance only | Full 4000-row legacy list |

## Test plan

- [ ] Open System Settings → 模型 → 定价比例 → 模型比例
- [ ] Confirm switch defaults to ON, table shows only models bound to an enabled channel
- [ ] Toggle OFF — full list returns
- [ ] Reload — toggle state persists
- [ ] Search box still works in both states
- [ ] Add a new Pixverse SKU price via "添加模型" — appears immediately when ON (since the model is bound to the Pixverse channel)
- [ ] Edit an existing row from the filtered view — save round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)