### PR TITLE
feat(seedance): wrap image input behind ARK asset audit (opt-in)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -37,3 +37,37 @@ STREAMING_TIMEOUT=300
 # --- 调试（按需打开）---
 # DEBUG=true
 # ENABLE_PPROF=true
+
+# ============================================================
+# 图片审核（Volcano ARK Assets + Tencent COS）
+# ============================================================
+# 当 video API 请求带 metadata.audit_image=true 时，
+# 网关会先把图片送审，审核通过再调上游生成。
+# 不传此参数则保持原行为（图片直接透传）。
+# ============================================================
+
+# --- 火山方舟 Assets API（素材审核） ---
+# AK/SK 见火山控制台 → 访问控制 → 访问密钥
+# Project 必须跟拿审核通过 asset 调推理时用的 API Key 同 project，
+# 否则推理时报 asset is not found
+ARK_AK=
+ARK_SK=
+ARK_ASSETS_PROJECT=default
+# 不填 GROUP_ID 时，按 GROUP_NAME 自动创建/复用一个 group
+ARK_ASSETS_GROUP_NAME=aikanhub-audit
+ARK_ASSETS_GROUP_ID=
+# 轮询审核状态的间隔/超时（秒）
+ARK_ASSETS_POLL_INTERVAL=3
+ARK_ASSETS_POLL_TIMEOUT=300
+
+# --- 腾讯云 COS（接收用户传入的 base64/二进制图片） ---
+# 用户传 URL 时跳过这一步；传 data:image/...;base64,... 时上传到 COS 拿公网 URL
+# 给 ARK CreateAsset 用。
+# 控制台 → 对象存储 → 桶详情；REGION 必须跟桶实际地域一致，否则签名失败。
+COS_BUCKET=
+COS_REGION=ap-shanghai
+COS_SECRET_ID=
+COS_SECRET_KEY=
+COS_OBJECT_PREFIX=aikanhub-audit/
+# 可选：套了 CDN 时填 CDN 域名，不填默认用 https://{bucket}.cos.{region}.myqcloud.com
+COS_PUBLIC_HOST=

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -37,6 +37,20 @@ services:
       - NODE_NAME=${NODE_NAME:-aikanhub-dev-1}
       - UPDATE_TASK=${UPDATE_TASK:-true}
       - STREAMING_TIMEOUT=${STREAMING_TIMEOUT:-300}
+      # 图片审核（imageaudit 包）
+      - ARK_AK=${ARK_AK:-}
+      - ARK_SK=${ARK_SK:-}
+      - ARK_ASSETS_PROJECT=${ARK_ASSETS_PROJECT:-default}
+      - ARK_ASSETS_GROUP_NAME=${ARK_ASSETS_GROUP_NAME:-aikanhub-audit}
+      - ARK_ASSETS_GROUP_ID=${ARK_ASSETS_GROUP_ID:-}
+      - ARK_ASSETS_POLL_INTERVAL=${ARK_ASSETS_POLL_INTERVAL:-3}
+      - ARK_ASSETS_POLL_TIMEOUT=${ARK_ASSETS_POLL_TIMEOUT:-300}
+      - COS_BUCKET=${COS_BUCKET:-}
+      - COS_REGION=${COS_REGION:-ap-shanghai}
+      - COS_SECRET_ID=${COS_SECRET_ID:-}
+      - COS_SECRET_KEY=${COS_SECRET_KEY:-}
+      - COS_OBJECT_PREFIX=${COS_OBJECT_PREFIX:-aikanhub-audit/}
+      - COS_PUBLIC_HOST=${COS_PUBLIC_HOST:-}
     depends_on:
       redis:
         condition: service_healthy

--- a/relay/channel/task/doubao/adaptor.go
+++ b/relay/channel/task/doubao/adaptor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/service/imageaudit"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
@@ -261,6 +262,16 @@ func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayIn
 	if err != nil {
 		return nil, errors.Wrap(err, "convert request payload failed")
 	}
+
+	// audit_image=true → run every image_url through ARK Assets audit before
+	// submitting upstream. Each URL becomes asset://<id>. Unset / false keeps
+	// the original passthrough behaviour.
+	if shouldAuditImages(req.Metadata) {
+		if err := a.auditImageContent(c, body); err != nil {
+			return nil, err
+		}
+	}
+
 	if info.IsModelMapped {
 		body.Model = info.UpstreamModelName
 	} else {
@@ -271,6 +282,58 @@ func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayIn
 		return nil, err
 	}
 	return bytes.NewReader(data), nil
+}
+
+// shouldAuditImages reports whether the caller asked for the audit pipeline.
+// The flag is read from req.Metadata so it works for both request shapes:
+//
+//   - OpenAI-form  POST /v1/videos with `metadata.audit_image: true`
+//   - Volcano-form POST /api/v3/contents/generations/tasks with `audit_image: true`
+//     at the top level (the volcArkSubmitConvert middleware copies the entire
+//     raw body into metadata, so the flag is reachable here either way).
+//
+// Truthy values: bool true, "true", "1", "yes", "on" (case-insensitive).
+// Anything else (including absent) → false → original passthrough.
+func shouldAuditImages(metadata map[string]any) bool {
+	if metadata == nil {
+		return false
+	}
+	switch v := metadata["audit_image"].(type) {
+	case bool:
+		return v
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "true", "1", "yes", "on":
+			return true
+		}
+	case float64:
+		return v != 0
+	case int:
+		return v != 0
+	}
+	return false
+}
+
+// auditImageContent walks body.Content, replaces every image_url URL with the
+// audited asset:// URI, and short-circuits with a clear error on the first
+// audit failure. Audit failures (Status=Failed) carry a stable error code so
+// API clients can distinguish moderation rejection from infrastructure issues.
+func (a *TaskAdaptor) auditImageContent(c *gin.Context, body *requestPayload) error {
+	for i := range body.Content {
+		item := &body.Content[i]
+		if item.Type != "image_url" || item.ImageURL == nil || item.ImageURL.URL == "" {
+			continue
+		}
+		audited, err := imageaudit.EnsureAuditedCached(c.Request.Context(), item.ImageURL.URL)
+		if err != nil {
+			if imageaudit.IsAuditFailure(err) {
+				return errors.Wrap(err, "image_audit_failed")
+			}
+			return errors.Wrap(err, "image_audit_error")
+		}
+		item.ImageURL.URL = audited
+	}
+	return nil
 }
 
 // DoRequest delegates to common helper.

--- a/service/imageaudit/ark.go
+++ b/service/imageaudit/ark.go
@@ -1,0 +1,427 @@
+package imageaudit
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+// Volcano ARK Assets API — uses Volcengine V4 signing (the same scheme as
+// e2e_audit_api_test.py in this repo's parent dir).
+//
+// Endpoints used:
+//   POST /  ?Action=CreateAssetGroup  Version=2024-01-01
+//   POST /  ?Action=ListAssetGroups   Version=2024-01-01
+//   POST /  ?Action=CreateAsset       Version=2024-01-01
+//   POST /  ?Action=GetAsset          Version=2024-01-01
+//
+// Request bodies are JSON; responses are {ResponseMetadata:{}, Result:{}}.
+
+const (
+	arkHost           = "ark.cn-beijing.volcengineapi.com"
+	arkRegion         = "cn-beijing"
+	arkService        = "ark"
+	arkVersion        = "2024-01-01"
+	arkContentType    = "application/json"
+	arkSignedHeaders  = "content-type;host;x-content-sha256;x-date"
+	arkRequestTimeout = 30 * time.Second
+)
+
+// arkResponse is the common envelope for every Assets call.
+type arkResponse struct {
+	ResponseMetadata struct {
+		RequestId string `json:"RequestId"`
+		Action    string `json:"Action"`
+		Region    string `json:"Region"`
+		Service   string `json:"Service"`
+		Version   string `json:"Version"`
+		Error     *struct {
+			Code    string `json:"Code"`
+			Message string `json:"Message"`
+		} `json:"Error,omitempty"`
+	} `json:"ResponseMetadata"`
+	Result json.RawMessage `json:"Result"`
+}
+
+// arkClient wraps the AK/SK + ProjectName so call sites don't repeat them.
+type arkClient struct {
+	cfg Config
+	hc  *http.Client
+}
+
+func newARKClient(cfg Config) *arkClient {
+	return &arkClient{
+		cfg: cfg,
+		hc:  &http.Client{Timeout: arkRequestTimeout},
+	}
+}
+
+// callAction issues a signed POST to the ARK control-plane and unmarshals the
+// `Result` field into out. Service-level errors (returned as a populated
+// ResponseMetadata.Error) come back as Go errors.
+func (c *arkClient) callAction(ctx context.Context, action string, body, out any) error {
+	if !c.cfg.HasARK() {
+		return fmt.Errorf("ARK credentials missing (ARK_AK / ARK_SK)")
+	}
+	// Inject ProjectName so callers don't have to remember.
+	bodyMap, err := toMap(body)
+	if err != nil {
+		return fmt.Errorf("ark.%s: marshal body: %w", action, err)
+	}
+	if _, ok := bodyMap["ProjectName"]; !ok && c.cfg.ARKProject != "" {
+		bodyMap["ProjectName"] = c.cfg.ARKProject
+	}
+	bodyBytes, err := json.Marshal(bodyMap)
+	if err != nil {
+		return fmt.Errorf("ark.%s: marshal merged body: %w", action, err)
+	}
+	bodySHA := sha256Hex(bodyBytes)
+
+	q := url.Values{}
+	q.Set("Action", action)
+	q.Set("Version", arkVersion)
+	headers := signV4(
+		"POST", arkHost, "/", q,
+		bodySHA,
+		c.cfg.ARKAk, c.cfg.ARKSk,
+		arkService, arkRegion,
+		arkContentType,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		"https://"+arkHost+"/?"+q.Encode(), bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("ark.%s: new request: %w", action, err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("ark.%s: do: %w", action, err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("ark.%s: read body: %w", action, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ark.%s: HTTP %d: %s", action, resp.StatusCode, truncate(string(respBody), 500))
+	}
+
+	var env arkResponse
+	if err := json.Unmarshal(respBody, &env); err != nil {
+		return fmt.Errorf("ark.%s: unmarshal envelope: %w; body=%s", action, err, truncate(string(respBody), 500))
+	}
+	if env.ResponseMetadata.Error != nil {
+		return fmt.Errorf("ark.%s: %s — %s",
+			action,
+			env.ResponseMetadata.Error.Code,
+			env.ResponseMetadata.Error.Message,
+		)
+	}
+	if out == nil || len(env.Result) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(env.Result, out); err != nil {
+		return fmt.Errorf("ark.%s: unmarshal Result: %w; result=%s", action, err, truncate(string(env.Result), 500))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// CreateAssetGroup / ListAssetGroups — used to obtain a stable group id.
+// ---------------------------------------------------------------------------
+
+type arkGroup struct {
+	Id          string `json:"Id"`
+	Name        string `json:"Name"`
+	GroupType   string `json:"GroupType"`
+	Description string `json:"Description"`
+}
+
+func (c *arkClient) createAssetGroup(ctx context.Context, name string) (string, error) {
+	body := map[string]any{
+		"Name":        name,
+		"GroupType":   "AIGC",
+		"Description": name,
+	}
+	var g arkGroup
+	if err := c.callAction(ctx, "CreateAssetGroup", body, &g); err != nil {
+		return "", err
+	}
+	if g.Id == "" {
+		return "", fmt.Errorf("CreateAssetGroup: empty Id in result")
+	}
+	return g.Id, nil
+}
+
+type listAssetGroupsResult struct {
+	Items []arkGroup `json:"Items"`
+	Total int        `json:"Total"`
+}
+
+func (c *arkClient) findAssetGroupByName(ctx context.Context, name string) (string, error) {
+	body := map[string]any{
+		"Filter":     map[string]any{"GroupType": "AIGC", "Name": name},
+		"PageNumber": 1,
+		"PageSize":   20,
+		"SortBy":     "CreateTime",
+		"SortOrder":  "Desc",
+	}
+	var res listAssetGroupsResult
+	if err := c.callAction(ctx, "ListAssetGroups", body, &res); err != nil {
+		return "", err
+	}
+	for _, g := range res.Items {
+		if g.Name == name {
+			return g.Id, nil
+		}
+	}
+	return "", nil
+}
+
+// ensureAssetGroup returns the configured GROUP_ID when set, else find-or-
+// create by GROUP_NAME. The result is cached on the client for the process'
+// lifetime so we only do the lookup once.
+func (c *arkClient) ensureAssetGroup(ctx context.Context) (string, error) {
+	if c.cfg.ARKGroupID != "" {
+		return c.cfg.ARKGroupID, nil
+	}
+	if c.cfg.ARKGroupName == "" {
+		return "", fmt.Errorf("either ARK_ASSETS_GROUP_ID or ARK_ASSETS_GROUP_NAME must be set")
+	}
+	if id, err := c.findAssetGroupByName(ctx, c.cfg.ARKGroupName); err != nil {
+		// Listing failed — surface the error rather than silently creating a duplicate.
+		return "", fmt.Errorf("findAssetGroupByName: %w", err)
+	} else if id != "" {
+		return id, nil
+	}
+	common.SysLog(fmt.Sprintf("imageaudit: creating new ARK asset group name=%s project=%s",
+		c.cfg.ARKGroupName, c.cfg.ARKProject))
+	return c.createAssetGroup(ctx, c.cfg.ARKGroupName)
+}
+
+// ---------------------------------------------------------------------------
+// CreateAsset / GetAsset — submit URL → poll → asset:// URI.
+// ---------------------------------------------------------------------------
+
+type arkAssetResult struct {
+	Id     string          `json:"Id"`
+	Status string          `json:"Status"`
+	URL    string          `json:"URL"`
+	Error  json.RawMessage `json:"Error,omitempty"`
+}
+
+func (c *arkClient) createAsset(ctx context.Context, groupId, imgURL string) (string, error) {
+	body := map[string]any{
+		"GroupId":   groupId,
+		"URL":       imgURL,
+		"AssetType": "Image",
+	}
+	var res arkAssetResult
+	if err := c.callAction(ctx, "CreateAsset", body, &res); err != nil {
+		return "", err
+	}
+	if res.Id == "" {
+		return "", fmt.Errorf("CreateAsset: empty Id in result")
+	}
+	return res.Id, nil
+}
+
+func (c *arkClient) getAsset(ctx context.Context, id string) (*arkAssetResult, error) {
+	body := map[string]any{"Id": id}
+	var res arkAssetResult
+	if err := c.callAction(ctx, "GetAsset", body, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// AuditError wraps an audit-stage failure so callers can distinguish it from
+// transient infra errors. Status carries the upstream Status string ("Failed",
+// "Processing", ...) and Reason carries Volcano's explanation when available.
+type AuditError struct {
+	AssetId string
+	Status  string
+	Reason  string
+}
+
+func (e *AuditError) Error() string {
+	if e.Reason != "" {
+		return fmt.Sprintf("image audit %s (asset=%s): %s", e.Status, e.AssetId, e.Reason)
+	}
+	return fmt.Sprintf("image audit %s (asset=%s)", e.Status, e.AssetId)
+}
+
+// pollAsset waits for the asset to leave Processing. Returns nil only when
+// Status == "Active". Wraps non-Active terminal states in *AuditError so
+// callers can present a stable error code to API clients.
+func (c *arkClient) pollAsset(ctx context.Context, id string) (*arkAssetResult, error) {
+	deadline := time.Now().Add(c.cfg.ARKPollTimeout)
+	last := ""
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		res, err := c.getAsset(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if res.Status != last {
+			common.SysLog(fmt.Sprintf("imageaudit: asset=%s status=%s", id, res.Status))
+			last = res.Status
+		}
+		switch res.Status {
+		case "Active":
+			return res, nil
+		case "Failed":
+			return nil, &AuditError{
+				AssetId: id,
+				Status:  res.Status,
+				Reason:  string(res.Error),
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("image audit timed out after %s (asset=%s, last status=%s)",
+				c.cfg.ARKPollTimeout, id, last)
+		}
+		// Sleep with cancel-awareness so a request cancellation aborts polling.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(c.cfg.ARKPollInterval):
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Volcengine V4 signing (same algorithm as the Python e2e script).
+// ---------------------------------------------------------------------------
+
+func signV4(method, host, path string, query url.Values, bodySHA256, ak, sk, service, region, contentType string) map[string]string {
+	now := time.Now().UTC()
+	xDate := now.Format("20060102T150405Z")
+	shortDate := xDate[:8]
+
+	canonical := strings.Join([]string{
+		strings.ToUpper(method),
+		path,
+		canonicalQueryString(query),
+		"content-type:" + contentType,
+		"host:" + host,
+		"x-content-sha256:" + bodySHA256,
+		"x-date:" + xDate,
+		"",
+		arkSignedHeaders,
+		bodySHA256,
+	}, "\n")
+	credScope := shortDate + "/" + region + "/" + service + "/request"
+	stringToSign := strings.Join([]string{
+		"HMAC-SHA256",
+		xDate,
+		credScope,
+		sha256Hex([]byte(canonical)),
+	}, "\n")
+
+	k := hmacSHA256([]byte(sk), shortDate)
+	k = hmacSHA256(k, region)
+	k = hmacSHA256(k, service)
+	k = hmacSHA256(k, "request")
+	signature := hex.EncodeToString(hmacSHA256(k, stringToSign))
+
+	return map[string]string{
+		"Host":             host,
+		"Content-Type":     contentType,
+		"X-Date":           xDate,
+		"X-Content-Sha256": bodySHA256,
+		"Authorization": fmt.Sprintf(
+			"HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+			ak, credScope, arkSignedHeaders, signature,
+		),
+	}
+}
+
+func canonicalQueryString(q url.Values) string {
+	if len(q) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(q))
+	for k := range q {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(q))
+	for _, k := range keys {
+		for _, v := range q[k] {
+			parts = append(parts,
+				volcanoQueryEscape(k)+"="+volcanoQueryEscape(v))
+		}
+	}
+	return strings.Join(parts, "&")
+}
+
+// volcanoQueryEscape mirrors the Python script's `quote(s, safe="-_.~")`.
+// url.QueryEscape escapes "+" oddly for our purposes — re-do it.
+func volcanoQueryEscape(s string) string {
+	enc := url.QueryEscape(s)
+	enc = strings.ReplaceAll(enc, "+", "%20")
+	return enc
+}
+
+func sha256Hex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(data))
+	return h.Sum(nil)
+}
+
+func toMap(v any) (map[string]any, error) {
+	if v == nil {
+		return map[string]any{}, nil
+	}
+	if m, ok := v.(map[string]any); ok {
+		// Copy so we don't mutate the caller's map when ProjectName is injected.
+		out := make(map[string]any, len(m)+1)
+		for k, vv := range m {
+			out[k] = vv
+		}
+		return out, nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]any)
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
+}

--- a/service/imageaudit/audit.go
+++ b/service/imageaudit/audit.go
@@ -1,0 +1,173 @@
+package imageaudit
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// EnsureAudited drives the full audit pipeline for a single image source and
+// returns the asset:// URI to substitute back into the upstream payload.
+//
+// src is whatever the user gave us:
+//
+//	http(s)://...                  → CreateAsset(src) → poll → asset://<id>
+//	data:image/...;base64,<b64>    → COS upload → CreateAsset(public URL) → poll → asset://<id>
+//	<bare base64 string>           → same as data: URI, MIME inferred
+//	asset://<id>                   → returned as-is (already-audited inputs are fine)
+//
+// On audit failure the error is *AuditError. On infra failures (creds missing,
+// COS upload failed, ARK 5xx, etc.) the error is a plain wrapped error.
+func EnsureAudited(ctx context.Context, src string) (string, error) {
+	src = strings.TrimSpace(src)
+	if src == "" {
+		return "", errors.New("imageaudit: empty image source")
+	}
+	if strings.HasPrefix(src, "asset://") {
+		// Already an audited reference — the caller pre-uploaded.
+		return src, nil
+	}
+
+	cfg := Load()
+	if !cfg.HasARK() {
+		return "", errors.New("imageaudit: ARK_AK / ARK_SK not configured")
+	}
+
+	// Step 1 — make sure we have a public URL to give CreateAsset.
+	publicURL, err := materializeURL(ctx, cfg, src)
+	if err != nil {
+		return "", fmt.Errorf("imageaudit: prepare URL: %w", err)
+	}
+
+	client := newARKClient(cfg)
+	groupId, err := client.ensureAssetGroup(ctx)
+	if err != nil {
+		return "", fmt.Errorf("imageaudit: ensureAssetGroup: %w", err)
+	}
+
+	// Step 2 — submit + poll.
+	assetID, err := client.createAsset(ctx, groupId, publicURL)
+	if err != nil {
+		return "", fmt.Errorf("imageaudit: createAsset: %w", err)
+	}
+	if _, err := client.pollAsset(ctx, assetID); err != nil {
+		// AuditError is preserved verbatim so callers can map to a stable code.
+		return "", err
+	}
+	return "asset://" + assetID, nil
+}
+
+// IsAuditFailure returns true when the error is the audit terminating in
+// Failed (vs. transient infra errors). Used by the relay layer to map to a
+// distinct user-facing error code.
+func IsAuditFailure(err error) bool {
+	var ae *AuditError
+	return errors.As(err, &ae)
+}
+
+// materializeURL ensures the audit pipeline has a public HTTPS URL to feed
+// CreateAsset. Plain http(s) URLs pass through; data URIs and bare base64
+// strings get uploaded to COS first.
+func materializeURL(ctx context.Context, cfg Config, src string) (string, error) {
+	if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
+		return src, nil
+	}
+	// Anything else has to be uploadable bytes. Decode + upload.
+	if !cfg.HasCOS() {
+		return "", errors.New("audit_image=true with non-URL source requires COS_BUCKET / COS_SECRET_ID / COS_SECRET_KEY")
+	}
+	raw, contentType, err := decodeDataURI(src)
+	if err != nil {
+		return "", fmt.Errorf("decode data URI: %w", err)
+	}
+	if len(raw) == 0 {
+		return "", errors.New("decoded image is empty")
+	}
+	objectKey := buildObjectKey(cfg.COSPrefix, contentType)
+	publicURL, err := uploadToCOS(ctx, cfg, objectKey, raw, contentType)
+	if err != nil {
+		return "", fmt.Errorf("cos upload: %w", err)
+	}
+	return publicURL, nil
+}
+
+// buildObjectKey produces a unique, short, predictable key like
+// "<prefix>/2026/05/07/<8-hex>.jpg" so collisions are impossible and traces
+// are sortable by date.
+func buildObjectKey(prefix, contentType string) string {
+	prefix = strings.Trim(prefix, "/")
+	if prefix == "" {
+		prefix = "aikanhub-audit"
+	}
+	now := time.Now().UTC()
+	day := now.Format("2006/01/02")
+	rb := make([]byte, 6)
+	_, _ = rand.Read(rb)
+	suffix := hex.EncodeToString(rb)
+	return fmt.Sprintf("%s/%s/%d-%s%s", prefix, day, now.UnixNano(), suffix, extOf(contentType))
+}
+
+// ---------------------------------------------------------------------------
+// Single-flight cache: when a video task carries multiple images that all need
+// auditing, the calling adapter loops over them serially. That's fine, but
+// callers that batch identical URLs (rare, but happens with templated
+// requests) shouldn't re-submit the same one. The cache below is process-
+// local and bounded — it's only optimization, never correctness.
+// ---------------------------------------------------------------------------
+
+type cachedResult struct {
+	asset    string
+	expireAt time.Time
+}
+
+var (
+	cacheMu sync.Mutex
+	cache   = make(map[string]cachedResult)
+)
+
+const cacheTTL = 30 * time.Minute
+
+// EnsureAuditedCached is EnsureAudited with a same-process best-effort cache
+// keyed by the source string. Use this from the hot path; bare EnsureAudited
+// is fine for tests.
+func EnsureAuditedCached(ctx context.Context, src string) (string, error) {
+	if cached, ok := cacheGet(src); ok {
+		return cached, nil
+	}
+	out, err := EnsureAudited(ctx, src)
+	if err != nil {
+		return "", err
+	}
+	cachePut(src, out)
+	return out, nil
+}
+
+func cacheGet(key string) (string, bool) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	c, ok := cache[key]
+	if !ok {
+		return "", false
+	}
+	if time.Now().After(c.expireAt) {
+		delete(cache, key)
+		return "", false
+	}
+	return c.asset, true
+}
+
+func cachePut(key, asset string) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	if len(cache) > 1000 {
+		// Crude eviction — drop everything. Audit decisions can re-derive on
+		// next request; we only care about avoiding unbounded growth.
+		cache = make(map[string]cachedResult)
+	}
+	cache[key] = cachedResult{asset: asset, expireAt: time.Now().Add(cacheTTL)}
+}

--- a/service/imageaudit/config.go
+++ b/service/imageaudit/config.go
@@ -1,0 +1,136 @@
+// Package imageaudit gates image-bearing video tasks behind Volcano ARK's
+// asset library audit. The flow is:
+//
+//	user image (URL or base64)
+//	    ↓
+//	(if base64) upload to Tencent COS → public URL
+//	    ↓
+//	ARK Assets API: CreateAsset(URL) → poll GetAsset until Active
+//	    ↓
+//	asset://<id>  ← gateway substitutes this in the upstream payload
+//
+// Triggered per-request via metadata.audit_image=true. Default off so existing
+// callers see no change.
+package imageaudit
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Config bundles every env value the audit pipeline needs. Values are read
+// once via Load(), TrimSpace'd to tolerate accidental "VAR=300   " padding,
+// and stripped of inline "# ..." comments to tolerate dotenv files that
+// keep comments next to the value.
+type Config struct {
+	// Volcano ARK Assets API.
+	ARKAk            string
+	ARKSk            string
+	ARKProject       string
+	ARKGroupName     string
+	ARKGroupID       string
+	ARKPollInterval  time.Duration
+	ARKPollTimeout   time.Duration
+
+	// Tencent COS (only required when callers send raw bytes; URL passthrough
+	// skips this entirely).
+	COSBucket     string
+	COSRegion     string
+	COSSecretID   string
+	COSSecretKey  string
+	COSPrefix     string
+	COSPublicHost string
+}
+
+// Load reads the audit config from process env. It never errors — missing
+// fields are reported by Validate*() at the moment they're actually needed.
+func Load() Config {
+	return Config{
+		ARKAk:           cleanEnv("ARK_AK"),
+		ARKSk:           cleanEnv("ARK_SK"),
+		ARKProject:      defaultIfEmpty(cleanEnv("ARK_ASSETS_PROJECT"), "default"),
+		ARKGroupName:    defaultIfEmpty(cleanEnv("ARK_ASSETS_GROUP_NAME"), "aikanhub-audit"),
+		ARKGroupID:      cleanEnv("ARK_ASSETS_GROUP_ID"),
+		ARKPollInterval: time.Duration(parseIntDefault(cleanEnv("ARK_ASSETS_POLL_INTERVAL"), 3)) * time.Second,
+		ARKPollTimeout:  time.Duration(parseIntDefault(cleanEnv("ARK_ASSETS_POLL_TIMEOUT"), 300)) * time.Second,
+
+		COSBucket:     cleanEnv("COS_BUCKET"),
+		COSRegion:     defaultIfEmpty(cleanEnv("COS_REGION"), "ap-shanghai"),
+		COSSecretID:   cleanEnv("COS_SECRET_ID"),
+		COSSecretKey:  cleanEnv("COS_SECRET_KEY"),
+		COSPrefix:     defaultIfEmpty(cleanEnv("COS_OBJECT_PREFIX"), "aikanhub-audit/"),
+		COSPublicHost: cleanEnv("COS_PUBLIC_HOST"),
+	}
+}
+
+// HasARK is true iff Volcano credentials are present. CreateAsset / GetAsset
+// require both AK and SK; we don't validate format.
+func (c Config) HasARK() bool {
+	return c.ARKAk != "" && c.ARKSk != ""
+}
+
+// HasCOS is true iff Tencent COS credentials and bucket are present.
+func (c Config) HasCOS() bool {
+	return c.COSBucket != "" && c.COSSecretID != "" && c.COSSecretKey != ""
+}
+
+// COSEndpoint returns the canonical "{bucket}.cos.{region}.myqcloud.com" host
+// used for both signing and the upload URL itself. PublicHost is only used
+// when handing the URL back to ARK; signing always goes against the cos.*
+// endpoint.
+func (c Config) COSEndpoint() string {
+	return c.COSBucket + ".cos." + c.COSRegion + ".myqcloud.com"
+}
+
+// PublicURL builds the externally-reachable URL given an object key. Falls
+// back to the canonical endpoint when COS_PUBLIC_HOST is empty.
+func (c Config) PublicURL(objectKey string) string {
+	host := strings.TrimRight(c.COSPublicHost, "/")
+	if host == "" {
+		host = "https://" + c.COSEndpoint()
+	}
+	if !strings.HasPrefix(objectKey, "/") {
+		objectKey = "/" + objectKey
+	}
+	return host + objectKey
+}
+
+// cleanEnv reads VAR, trims whitespace, and strips a trailing inline
+// "# ..." comment when one slipped in. Standard dotenv parsers tolerate this
+// inconsistently; trimming it here means env files like
+//
+//	ARK_ASSETS_POLL_TIMEOUT=300   # 秒
+//
+// load as 300 instead of "300   # 秒".
+func cleanEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		return ""
+	}
+	// Don't strip # inside quoted values — but our env values never have #
+	// legitimately, so a simple split is fine.
+	if i := strings.Index(v, "#"); i >= 0 {
+		v = v[:i]
+	}
+	return strings.TrimSpace(v)
+}
+
+func defaultIfEmpty(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}
+
+func parseIntDefault(s string, fallback int) int {
+	if s == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		return fallback
+	}
+	return n
+}

--- a/service/imageaudit/cos.go
+++ b/service/imageaudit/cos.go
@@ -1,0 +1,253 @@
+package imageaudit
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Tencent COS uses its own V5 signing scheme (q-sign-algorithm=sha1) — NOT
+// AWS SigV4 — so we implement it manually rather than pulling in the official
+// SDK (~1MB). See https://cloud.tencent.com/document/product/436/7778 for the
+// full spec.
+//
+// Algorithm:
+//
+//	SignKey      = HMAC-SHA1(SecretKey, KeyTime)
+//	HttpString   = method "\n" path "\n" canonicalQuery "\n" canonicalHeaders "\n"
+//	StringToSign = "sha1" "\n" KeyTime "\n" sha1(HttpString) "\n"
+//	Signature    = HMAC-SHA1(SignKey, StringToSign)
+//
+// Authorization header is a flat URL-style string of fields.
+
+const cosUploadTimeout = 120 * time.Second
+
+// uploadToCOS PUTs a single object and returns its public URL.
+//
+// objectKey must NOT start with a leading slash; the implementation adds one.
+// contentType is sent as-is (Tencent COS preserves it on download).
+func uploadToCOS(ctx context.Context, cfg Config, objectKey string, body []byte, contentType string) (string, error) {
+	if !cfg.HasCOS() {
+		return "", fmt.Errorf("COS not configured (need COS_BUCKET / COS_SECRET_ID / COS_SECRET_KEY)")
+	}
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	objectKey = strings.TrimLeft(objectKey, "/")
+	pathname := "/" + objectKey
+	host := cfg.COSEndpoint()
+
+	headers := map[string]string{
+		"Host":           host,
+		"Content-Type":   contentType,
+		"Content-Length": strconv.Itoa(len(body)),
+		"x-cos-acl":      "public-read", // ARK CreateAsset must be able to fetch
+	}
+
+	auth := signCOS("put", pathname, nil, headers, cfg.COSSecretID, cfg.COSSecretKey, 600)
+	headers["Authorization"] = auth
+
+	req, err := http.NewRequestWithContext(ctx, "PUT",
+		"https://"+host+pathname, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("cos: new request: %w", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	hc := &http.Client{Timeout: cosUploadTimeout}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("cos: do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("cos: PUT %s → HTTP %d: %s",
+			pathname, resp.StatusCode, truncate(string(respBody), 500))
+	}
+	return cfg.PublicURL(pathname), nil
+}
+
+// signCOS implements Tencent COS V5 signing.
+//
+// expiresIn controls the q-key-time / q-sign-time window in seconds. PUT
+// uploads can use a short window since the request is sent immediately.
+func signCOS(method, pathname string, params map[string]string, headers map[string]string,
+	secretID, secretKey string, expiresIn int64) string {
+
+	method = strings.ToLower(method)
+	now := time.Now().Unix()
+	keyTime := fmt.Sprintf("%d;%d", now-60, now+expiresIn)
+
+	// q-sign-key.
+	signKey := hexHMAC1([]byte(secretKey), keyTime)
+
+	// q-header-list / q-url-param-list — both lower-cased, sorted, ;-joined.
+	hdrKeys, canonicalHeaders := canonicalCOSPairs(headers)
+	paramKeys, canonicalParams := canonicalCOSPairs(stringMap(params))
+
+	httpString := strings.Join([]string{
+		method,
+		pathname,
+		canonicalParams,
+		canonicalHeaders,
+		"",
+	}, "\n")
+	stringToSign := strings.Join([]string{
+		"sha1",
+		keyTime,
+		sha1Hex([]byte(httpString)),
+		"",
+	}, "\n")
+	signature := hexHMAC1([]byte(signKey), stringToSign)
+
+	parts := []string{
+		"q-sign-algorithm=sha1",
+		"q-ak=" + secretID,
+		"q-sign-time=" + keyTime,
+		"q-key-time=" + keyTime,
+		"q-header-list=" + strings.Join(hdrKeys, ";"),
+		"q-url-param-list=" + strings.Join(paramKeys, ";"),
+		"q-signature=" + signature,
+	}
+	return strings.Join(parts, "&")
+}
+
+// canonicalCOSPairs returns (sortedLowercaseKeys, "k1=v1&k2=v2&...") with
+// keys lowercased and values percent-encoded per the COS spec (rfc3986
+// reserve set with case-insensitive sort).
+func canonicalCOSPairs(in map[string]string) ([]string, string) {
+	if len(in) == 0 {
+		return []string{}, ""
+	}
+	type kv struct{ k, v string }
+	pairs := make([]kv, 0, len(in))
+	for k, v := range in {
+		pairs = append(pairs, kv{strings.ToLower(k), v})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].k < pairs[j].k })
+
+	keys := make([]string, 0, len(pairs))
+	parts := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		keys = append(keys, p.k)
+		parts = append(parts, cosEscape(p.k)+"="+cosEscape(p.v))
+	}
+	return keys, strings.Join(parts, "&")
+}
+
+// cosEscape is rfc3986 unreserved + "-_.~".
+func cosEscape(s string) string {
+	// url.QueryEscape produces application/x-www-form-urlencoded encoding,
+	// which uses "+" for space — COS expects %20. Patch it.
+	return strings.ReplaceAll(url.QueryEscape(s), "+", "%20")
+}
+
+func sha1Hex(b []byte) string {
+	h := sha1.Sum(b)
+	return hex.EncodeToString(h[:])
+}
+
+func hexHMAC1(key []byte, data string) string {
+	h := hmac.New(sha1.New, key)
+	h.Write([]byte(data))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func stringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return map[string]string{}
+	}
+	return m
+}
+
+// inferContentType guesses a MIME type from a base64 data URI's metadata, or
+// falls back by sniffing the first bytes of decoded content. Used so the
+// COS upload presents a sensible Content-Type to ARK.
+func inferContentType(dataURI string, decoded []byte) string {
+	if strings.HasPrefix(dataURI, "data:") {
+		if i := strings.Index(dataURI, ";"); i > 5 {
+			return dataURI[5:i]
+		}
+		if i := strings.Index(dataURI, ","); i > 5 {
+			return dataURI[5:i]
+		}
+	}
+	if t := http.DetectContentType(decoded); t != "" && t != "application/octet-stream" {
+		return t
+	}
+	return "image/jpeg"
+}
+
+// extOf maps a content-type back to a usable file extension for the COS
+// object key. Known image/* values get specific suffixes; everything else
+// falls back to ".bin".
+func extOf(contentType string) string {
+	switch strings.ToLower(contentType) {
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/webp":
+		return ".webp"
+	case "image/gif":
+		return ".gif"
+	case "image/bmp":
+		return ".bmp"
+	case "image/heic":
+		return ".heic"
+	case "image/heif":
+		return ".heif"
+	}
+	return ".bin"
+}
+
+// decodeDataURI unwraps a "data:[<mime>][;base64],<payload>" URI and returns
+// the raw bytes plus the inferred MIME type. base64 is the only encoding we
+// support — bare data: URIs ("data:,hi") are rare for images and out of scope.
+func decodeDataURI(s string) ([]byte, string, error) {
+	if !strings.HasPrefix(s, "data:") {
+		// Not a data URI — assume a bare base64 string.
+		raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(s))
+		if err != nil {
+			return nil, "", fmt.Errorf("decode bare base64: %w", err)
+		}
+		return raw, http.DetectContentType(raw), nil
+	}
+	comma := strings.Index(s, ",")
+	if comma < 0 {
+		return nil, "", fmt.Errorf("malformed data URI (no comma)")
+	}
+	header, payload := s[:comma], s[comma+1:]
+	contentType := inferContentType(s, nil)
+	if !strings.Contains(header, ";base64") {
+		// Plain (URL-encoded) data URI — decode as-is.
+		decoded, err := url.QueryUnescape(payload)
+		if err != nil {
+			return nil, "", fmt.Errorf("decode percent-encoded data URI: %w", err)
+		}
+		return []byte(decoded), contentType, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(payload))
+	if err != nil {
+		return nil, "", fmt.Errorf("decode base64 data URI: %w", err)
+	}
+	if contentType == "" {
+		contentType = http.DetectContentType(raw)
+	}
+	return raw, contentType, nil
+}

--- a/web/default/src/features/docs/index.tsx
+++ b/web/default/src/features/docs/index.tsx
@@ -217,90 +217,6 @@ video = client.videos.create(
 )
 print(video.id)`
 
-// ----------------------------------------------------------------------------
-// Image audit examples — same /v1/video/generations endpoint as the rest of
-// Seedance, only the metadata.audit_image flag is added. The gateway runs
-// every input image through Volcano ARK's asset library before submitting,
-// so real-person photos that would otherwise trip Seedance's privacy filter
-// pass through cleanly.
-// ----------------------------------------------------------------------------
-
-const CURL_AUDIT_URL = `curl -X POST ${ENDPOINT_BASE}/v1/video/generations \\
-  -H "Authorization: Bearer $AIKANHUB_TOKEN" \\
-  -H "Content-Type: application/json" \\
-  -d '{
-    "model": "doubao-seedance-2-0-fast-260128",
-    "prompt": "gently animate the portrait",
-    "images": ["https://your.cdn/face.jpg"],
-    "metadata": { "audit_image": true }
-  }'`
-
-const CURL_AUDIT_BASE64 = `# Base64 path — gateway uploads to Tencent COS first.
-B64=$(base64 -i ./face.jpg | tr -d '\\n')
-{
-  echo -n '{"model":"doubao-seedance-2-0-fast-260128","prompt":"gently animate the portrait","metadata":{"audit_image":true},"images":["data:image/jpeg;base64,'
-  echo "$B64"
-  echo -n '"]}'
-} > /tmp/payload.json
-
-curl -X POST ${ENDPOINT_BASE}/v1/video/generations \\
-  -H "Authorization: Bearer $AIKANHUB_TOKEN" \\
-  -H "Content-Type: application/json" \\
-  --data-binary @/tmp/payload.json`
-
-const CURL_AUDIT_VOLC = `# Volcano Ark SDK shape — flag goes at the top level, not in metadata.
-curl -X POST ${ENDPOINT_BASE}/api/v3/contents/generations/tasks \\
-  -H "Authorization: Bearer $AIKANHUB_TOKEN" \\
-  -H "Content-Type: application/json" \\
-  -d '{
-    "model": "doubao-seedance-2-0-fast-260128",
-    "audit_image": true,
-    "content": [
-      {"type": "text", "text": "gently animate the portrait"},
-      {"type": "image_url", "image_url": {"url": "https://your.cdn/face.jpg"}}
-    ]
-  }'`
-
-const PY_AUDIT_URL = `# pip install openai
-import os
-from openai import OpenAI
-
-client = OpenAI(
-    api_key=os.environ["AIKANHUB_TOKEN"],
-    base_url="${ENDPOINT_BASE}/v1",
-)
-
-video = client.videos.create(
-    model="doubao-seedance-2-0-fast-260128",
-    prompt="gently animate the portrait",
-    extra_body={
-        "images": ["https://your.cdn/face.jpg"],
-        "metadata": {"audit_image": True},
-    },
-)
-print(video.id)`
-
-const PY_AUDIT_BASE64 = `# pip install openai
-import base64, os
-from openai import OpenAI
-
-with open("face.jpg", "rb") as f:
-    b64 = base64.b64encode(f.read()).decode()
-
-client = OpenAI(
-    api_key=os.environ["AIKANHUB_TOKEN"],
-    base_url="${ENDPOINT_BASE}/v1",
-)
-video = client.videos.create(
-    model="doubao-seedance-2-0-fast-260128",
-    prompt="gently animate the portrait",
-    extra_body={
-        "images": [f"data:image/jpeg;base64,{b64}"],
-        "metadata": {"audit_image": True},
-    },
-)
-print(video.id)`
-
 const CURL_POLL = `curl ${ENDPOINT_BASE}/v1/video/generations/$TASK_ID \\
   -H "Authorization: Bearer $AIKANHUB_TOKEN"`
 
@@ -947,7 +863,6 @@ export function Docs() {
           },
           { id: 'params', label: t('Full request parameters') },
           { id: 'media-limits', label: t('Input file limits') },
-          { id: 'audit-image', label: t('Image audit (audit_image)'), method: 'POST', isNew: true },
         ],
       },
       {
@@ -1458,6 +1373,13 @@ export function Docs() {
                       'is sugar for the first frame — equivalent to passing a single image_url entry with role first_frame inside metadata.content. Use the full structure when you need finer control.'
                     )}
                   </Callout>
+                  <Callout type='warn'>
+                    <strong>{t('Real-person reference image?')}</strong>{' '}
+                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>{' '}
+                    {t(
+                      'so the gateway sends the image to ARK\'s asset library audit first and substitutes asset://<id> upstream. Without this flag a real-person photo will trip Seedance\'s privacy filter and the request fails outright. Adds ~10–30 s before task_id is returned.'
+                    )}
+                  </Callout>
                 </Section>
 
                 <Section
@@ -1477,6 +1399,13 @@ export function Docs() {
                     <K>last_frame</K>{' '}
                     {t("— otherwise the model can't infer the time order.")}
                   </p>
+                  <Callout type='warn'>
+                    <strong>{t('Real-person reference image?')}</strong>{' '}
+                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>{' '}
+                    {t(
+                      'so the gateway sends the image to ARK\'s asset library audit first and substitutes asset://<id> upstream. Without this flag a real-person photo will trip Seedance\'s privacy filter and the request fails outright. Adds ~10–30 s before task_id is returned.'
+                    )}
+                  </Callout>
                 </Section>
 
                 <Section
@@ -1509,6 +1438,13 @@ export function Docs() {
                     </a>
                     .
                   </Callout>
+                  <Callout type='warn'>
+                    <strong>{t('Real-person reference image?')}</strong>{' '}
+                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>{' '}
+                    {t(
+                      'so the gateway sends the image to ARK\'s asset library audit first and substitutes asset://<id> upstream. Without this flag a real-person photo will trip Seedance\'s privacy filter and the request fails outright. Adds ~10–30 s before task_id is returned.'
+                    )}
+                  </Callout>
                 </Section>
 
                 <Section
@@ -1529,6 +1465,13 @@ export function Docs() {
                       'Combine a reference video with reference image(s) and a prompt that describes the edit, e.g. "Replace the perfume in video1 with the cream from image1; keep camera motion intact".'
                     )}
                   </p>
+                  <Callout type='warn'>
+                    <strong>{t('Real-person reference image?')}</strong>{' '}
+                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>{' '}
+                    {t(
+                      'so the gateway sends the image to ARK\'s asset library audit first and substitutes asset://<id> upstream. Without this flag a real-person photo will trip Seedance\'s privacy filter and the request fails outright. Adds ~10–30 s before task_id is returned.'
+                    )}
+                  </Callout>
                 </Section>
 
                 <Section
@@ -1899,159 +1842,6 @@ export function Docs() {
                   <Callout type='info'>
                     {t(
                       'Media inputs accept either a public URL or Base64 (data:image/png;base64,...). For large files, prefer URL to avoid oversized request bodies.'
-                    )}
-                  </Callout>
-                </Section>
-
-                <Section
-                  id='audit-image'
-                  title={
-                    <>
-                      {t('Image audit (audit_image)')}
-                      <NewBadge />
-                    </>
-                  }
-                  description={t(
-                    'Opt-in flag that wraps every input image in Volcano ARK\'s asset library audit before submitting upstream. Real-person photos that would otherwise be blocked by Seedance\'s privacy filter pass through cleanly.',
-                  )}
-                >
-                  <Callout type='tip'>
-                    <strong>{t('When to enable:')}</strong>{' '}
-                    {t(
-                      "any time the input image contains a recognizable face, especially of a child or any real person. Without this flag the upstream returns InputImageSensitiveContentDetected.PrivacyInformation and the request fails outright. With the flag the gateway uploads, audits, and substitutes asset://<id> for you.",
-                    )}
-                  </Callout>
-
-                  <h3 className='text-base font-medium'>{t('How it works')}</h3>
-                  <ol className='text-muted-foreground list-decimal space-y-1 pl-6 text-sm'>
-                    <li>
-                      {t('If the image is')} <K>http(s)://...</K>{' '}
-                      {t('the gateway forwards the URL to')} <K>CreateAsset</K>{' '}
-                      {t('directly. Otherwise it decodes the')} <K>data:image/...;base64,...</K>{' '}
-                      {t('payload and uploads to Tencent COS to obtain a public URL first.')}
-                    </li>
-                    <li>
-                      {t('CreateAsset returns an')} <K>asset_id</K>;{' '}
-                      {t('the gateway polls')} <K>GetAsset</K>{' '}
-                      {t('every 3 s until')} <K>Status=Active</K>{' '}
-                      {t('(typical: 10–30 s).')}
-                    </li>
-                    <li>
-                      {t('Each')} <K>image_url</K>{' '}
-                      {t('in the upstream payload is rewritten to')} <K>asset://&lt;id&gt;</K>;{' '}
-                      {t('the original URL never reaches Seedance, so the privacy filter has nothing to flag.')}
-                    </li>
-                    <li>
-                      {t('Audit failure surfaces as')} <K>image_audit_failed</K>{' '}
-                      {t('with the upstream code/message, so you can distinguish moderation rejection from infra issues.')}
-                    </li>
-                  </ol>
-
-                  <h3 className='pt-4 text-base font-medium'>
-                    {t('OpenAI shape — public URL')}
-                  </h3>
-                  <CodeTabs shell={CURL_AUDIT_URL} python={PY_AUDIT_URL} />
-
-                  <h3 className='pt-4 text-base font-medium'>
-                    {t('OpenAI shape — base64 (gateway uploads to COS)')}
-                  </h3>
-                  <CodeTabs shell={CURL_AUDIT_BASE64} python={PY_AUDIT_BASE64} />
-
-                  <h3 className='pt-4 text-base font-medium'>
-                    {t('Volcano Ark SDK shape')}
-                  </h3>
-                  <p className='text-muted-foreground text-sm'>
-                    {t('When using the Ark SDK, the flag goes at the top level rather than inside metadata — the gateway middleware copies the entire request body into metadata so a single field works for both shapes.')}
-                  </p>
-                  <CodeBlock lang='shell' code={CURL_AUDIT_VOLC} />
-
-                  <h3 className='pt-4 text-base font-medium'>{t('Parameter reference')}</h3>
-                  <ParamTable
-                    fieldLabel={t('Field')}
-                    typeLabel={t('Type')}
-                    requiredLabel={t('Required')}
-                    descLabel={t('Description')}
-                    yes={t('yes')}
-                    no={t('no')}
-                    params={[
-                      {
-                        name: 'metadata.audit_image',
-                        type: 'boolean',
-                        desc: t(
-                          'Set true to enable. Accepts true / "true" / 1 / "yes" / "on". Absent or false → original passthrough behavior, byte-identical to today.',
-                        ),
-                      },
-                      {
-                        name: 'images[]',
-                        type: 'string[]',
-                        desc: (
-                          <>
-                            {t('Each entry may be:')}
-                            <ul className='mt-1 list-disc space-y-0.5 pl-5'>
-                              <li>
-                                <K>http(s)://...</K> — {t('passthrough; gateway hands it to CreateAsset as-is.')}
-                              </li>
-                              <li>
-                                <K>data:image/...;base64,...</K> — {t('decoded, uploaded to COS, then audited.')}
-                              </li>
-                              <li>
-                                <K>asset://&lt;id&gt;</K> — {t('treated as already-audited; no-op.')}
-                              </li>
-                              <li>
-                                {t('Bare base64 string (no data: prefix) — sniffed for MIME and uploaded.')}
-                              </li>
-                            </ul>
-                          </>
-                        ),
-                      },
-                    ]}
-                  />
-
-                  <h3 className='pt-4 text-base font-medium'>
-                    {t('Failure shapes')}
-                  </h3>
-                  <div className='overflow-hidden rounded-lg border'>
-                    <table className='w-full text-sm'>
-                      <thead className='bg-muted'>
-                        <tr className='text-left'>
-                          <th className='px-4 py-2 font-medium'>code</th>
-                          <th className='px-4 py-2 font-medium'>{t('When')}</th>
-                          <th className='px-4 py-2 font-medium'>{t('What to do')}</th>
-                        </tr>
-                      </thead>
-                      <tbody className='divide-y text-xs'>
-                        {[
-                          [
-                            'image_audit_failed',
-                            t('Audit terminated with Status=Failed (Volcano moderation rejected the image).'),
-                            t('Show the user the upstream Reason and ask them to retry with a different image.'),
-                          ],
-                          [
-                            'image_audit_error',
-                            t('Audit pipeline error before reaching a verdict — credentials missing, COS upload failed, ARK 5xx, etc.'),
-                            t('Retry-able. Check ARK / COS env vars and the gateway logs.'),
-                          ],
-                        ].map((row, i) => (
-                          <tr key={i}>
-                            <td className='px-4 py-2 font-mono'>{row[0]}</td>
-                            <td className='px-4 py-2'>{row[1]}</td>
-                            <td className='px-4 py-2 text-muted-foreground'>{row[2]}</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-
-                  <Callout type='warn'>
-                    <strong>{t('Latency:')}</strong>{' '}
-                    {t(
-                      'audit adds ~10–30 s synchronous wait before /v1/video/generations returns the task_id. Plan client timeouts accordingly. The video generation itself happens after the gateway has substituted the asset:// URI, so it is unaffected.',
-                    )}
-                  </Callout>
-                  <Callout type='info'>
-                    <strong>{t('Op note:')}</strong>{' '}
-                    {t(
-                      'this feature requires ARK_AK / ARK_SK and (when callers send base64) COS_BUCKET / COS_SECRET_ID / COS_SECRET_KEY in the gateway env. ARK_ASSETS_PROJECT must match the project of the API key the seedance channel uses, or the asset:// reference will not be findable at inference time.',
                     )}
                   </Callout>
                 </Section>

--- a/web/default/src/features/docs/index.tsx
+++ b/web/default/src/features/docs/index.tsx
@@ -217,6 +217,90 @@ video = client.videos.create(
 )
 print(video.id)`
 
+// ----------------------------------------------------------------------------
+// Image audit examples — same /v1/video/generations endpoint as the rest of
+// Seedance, only the metadata.audit_image flag is added. The gateway runs
+// every input image through Volcano ARK's asset library before submitting,
+// so real-person photos that would otherwise trip Seedance's privacy filter
+// pass through cleanly.
+// ----------------------------------------------------------------------------
+
+const CURL_AUDIT_URL = `curl -X POST ${ENDPOINT_BASE}/v1/video/generations \\
+  -H "Authorization: Bearer $AIKANHUB_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "doubao-seedance-2-0-fast-260128",
+    "prompt": "gently animate the portrait",
+    "images": ["https://your.cdn/face.jpg"],
+    "metadata": { "audit_image": true }
+  }'`
+
+const CURL_AUDIT_BASE64 = `# Base64 path — gateway uploads to Tencent COS first.
+B64=$(base64 -i ./face.jpg | tr -d '\\n')
+{
+  echo -n '{"model":"doubao-seedance-2-0-fast-260128","prompt":"gently animate the portrait","metadata":{"audit_image":true},"images":["data:image/jpeg;base64,'
+  echo "$B64"
+  echo -n '"]}'
+} > /tmp/payload.json
+
+curl -X POST ${ENDPOINT_BASE}/v1/video/generations \\
+  -H "Authorization: Bearer $AIKANHUB_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  --data-binary @/tmp/payload.json`
+
+const CURL_AUDIT_VOLC = `# Volcano Ark SDK shape — flag goes at the top level, not in metadata.
+curl -X POST ${ENDPOINT_BASE}/api/v3/contents/generations/tasks \\
+  -H "Authorization: Bearer $AIKANHUB_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "doubao-seedance-2-0-fast-260128",
+    "audit_image": true,
+    "content": [
+      {"type": "text", "text": "gently animate the portrait"},
+      {"type": "image_url", "image_url": {"url": "https://your.cdn/face.jpg"}}
+    ]
+  }'`
+
+const PY_AUDIT_URL = `# pip install openai
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["AIKANHUB_TOKEN"],
+    base_url="${ENDPOINT_BASE}/v1",
+)
+
+video = client.videos.create(
+    model="doubao-seedance-2-0-fast-260128",
+    prompt="gently animate the portrait",
+    extra_body={
+        "images": ["https://your.cdn/face.jpg"],
+        "metadata": {"audit_image": True},
+    },
+)
+print(video.id)`
+
+const PY_AUDIT_BASE64 = `# pip install openai
+import base64, os
+from openai import OpenAI
+
+with open("face.jpg", "rb") as f:
+    b64 = base64.b64encode(f.read()).decode()
+
+client = OpenAI(
+    api_key=os.environ["AIKANHUB_TOKEN"],
+    base_url="${ENDPOINT_BASE}/v1",
+)
+video = client.videos.create(
+    model="doubao-seedance-2-0-fast-260128",
+    prompt="gently animate the portrait",
+    extra_body={
+        "images": [f"data:image/jpeg;base64,{b64}"],
+        "metadata": {"audit_image": True},
+    },
+)
+print(video.id)`
+
 const CURL_POLL = `curl ${ENDPOINT_BASE}/v1/video/generations/$TASK_ID \\
   -H "Authorization: Bearer $AIKANHUB_TOKEN"`
 
@@ -863,6 +947,7 @@ export function Docs() {
           },
           { id: 'params', label: t('Full request parameters') },
           { id: 'media-limits', label: t('Input file limits') },
+          { id: 'audit-image', label: t('Image audit (audit_image)'), method: 'POST', isNew: true },
         ],
       },
       {
@@ -1814,6 +1899,159 @@ export function Docs() {
                   <Callout type='info'>
                     {t(
                       'Media inputs accept either a public URL or Base64 (data:image/png;base64,...). For large files, prefer URL to avoid oversized request bodies.'
+                    )}
+                  </Callout>
+                </Section>
+
+                <Section
+                  id='audit-image'
+                  title={
+                    <>
+                      {t('Image audit (audit_image)')}
+                      <NewBadge />
+                    </>
+                  }
+                  description={t(
+                    'Opt-in flag that wraps every input image in Volcano ARK\'s asset library audit before submitting upstream. Real-person photos that would otherwise be blocked by Seedance\'s privacy filter pass through cleanly.',
+                  )}
+                >
+                  <Callout type='tip'>
+                    <strong>{t('When to enable:')}</strong>{' '}
+                    {t(
+                      "any time the input image contains a recognizable face, especially of a child or any real person. Without this flag the upstream returns InputImageSensitiveContentDetected.PrivacyInformation and the request fails outright. With the flag the gateway uploads, audits, and substitutes asset://<id> for you.",
+                    )}
+                  </Callout>
+
+                  <h3 className='text-base font-medium'>{t('How it works')}</h3>
+                  <ol className='text-muted-foreground list-decimal space-y-1 pl-6 text-sm'>
+                    <li>
+                      {t('If the image is')} <K>http(s)://...</K>{' '}
+                      {t('the gateway forwards the URL to')} <K>CreateAsset</K>{' '}
+                      {t('directly. Otherwise it decodes the')} <K>data:image/...;base64,...</K>{' '}
+                      {t('payload and uploads to Tencent COS to obtain a public URL first.')}
+                    </li>
+                    <li>
+                      {t('CreateAsset returns an')} <K>asset_id</K>;{' '}
+                      {t('the gateway polls')} <K>GetAsset</K>{' '}
+                      {t('every 3 s until')} <K>Status=Active</K>{' '}
+                      {t('(typical: 10–30 s).')}
+                    </li>
+                    <li>
+                      {t('Each')} <K>image_url</K>{' '}
+                      {t('in the upstream payload is rewritten to')} <K>asset://&lt;id&gt;</K>;{' '}
+                      {t('the original URL never reaches Seedance, so the privacy filter has nothing to flag.')}
+                    </li>
+                    <li>
+                      {t('Audit failure surfaces as')} <K>image_audit_failed</K>{' '}
+                      {t('with the upstream code/message, so you can distinguish moderation rejection from infra issues.')}
+                    </li>
+                  </ol>
+
+                  <h3 className='pt-4 text-base font-medium'>
+                    {t('OpenAI shape — public URL')}
+                  </h3>
+                  <CodeTabs shell={CURL_AUDIT_URL} python={PY_AUDIT_URL} />
+
+                  <h3 className='pt-4 text-base font-medium'>
+                    {t('OpenAI shape — base64 (gateway uploads to COS)')}
+                  </h3>
+                  <CodeTabs shell={CURL_AUDIT_BASE64} python={PY_AUDIT_BASE64} />
+
+                  <h3 className='pt-4 text-base font-medium'>
+                    {t('Volcano Ark SDK shape')}
+                  </h3>
+                  <p className='text-muted-foreground text-sm'>
+                    {t('When using the Ark SDK, the flag goes at the top level rather than inside metadata — the gateway middleware copies the entire request body into metadata so a single field works for both shapes.')}
+                  </p>
+                  <CodeBlock lang='shell' code={CURL_AUDIT_VOLC} />
+
+                  <h3 className='pt-4 text-base font-medium'>{t('Parameter reference')}</h3>
+                  <ParamTable
+                    fieldLabel={t('Field')}
+                    typeLabel={t('Type')}
+                    requiredLabel={t('Required')}
+                    descLabel={t('Description')}
+                    yes={t('yes')}
+                    no={t('no')}
+                    params={[
+                      {
+                        name: 'metadata.audit_image',
+                        type: 'boolean',
+                        desc: t(
+                          'Set true to enable. Accepts true / "true" / 1 / "yes" / "on". Absent or false → original passthrough behavior, byte-identical to today.',
+                        ),
+                      },
+                      {
+                        name: 'images[]',
+                        type: 'string[]',
+                        desc: (
+                          <>
+                            {t('Each entry may be:')}
+                            <ul className='mt-1 list-disc space-y-0.5 pl-5'>
+                              <li>
+                                <K>http(s)://...</K> — {t('passthrough; gateway hands it to CreateAsset as-is.')}
+                              </li>
+                              <li>
+                                <K>data:image/...;base64,...</K> — {t('decoded, uploaded to COS, then audited.')}
+                              </li>
+                              <li>
+                                <K>asset://&lt;id&gt;</K> — {t('treated as already-audited; no-op.')}
+                              </li>
+                              <li>
+                                {t('Bare base64 string (no data: prefix) — sniffed for MIME and uploaded.')}
+                              </li>
+                            </ul>
+                          </>
+                        ),
+                      },
+                    ]}
+                  />
+
+                  <h3 className='pt-4 text-base font-medium'>
+                    {t('Failure shapes')}
+                  </h3>
+                  <div className='overflow-hidden rounded-lg border'>
+                    <table className='w-full text-sm'>
+                      <thead className='bg-muted'>
+                        <tr className='text-left'>
+                          <th className='px-4 py-2 font-medium'>code</th>
+                          <th className='px-4 py-2 font-medium'>{t('When')}</th>
+                          <th className='px-4 py-2 font-medium'>{t('What to do')}</th>
+                        </tr>
+                      </thead>
+                      <tbody className='divide-y text-xs'>
+                        {[
+                          [
+                            'image_audit_failed',
+                            t('Audit terminated with Status=Failed (Volcano moderation rejected the image).'),
+                            t('Show the user the upstream Reason and ask them to retry with a different image.'),
+                          ],
+                          [
+                            'image_audit_error',
+                            t('Audit pipeline error before reaching a verdict — credentials missing, COS upload failed, ARK 5xx, etc.'),
+                            t('Retry-able. Check ARK / COS env vars and the gateway logs.'),
+                          ],
+                        ].map((row, i) => (
+                          <tr key={i}>
+                            <td className='px-4 py-2 font-mono'>{row[0]}</td>
+                            <td className='px-4 py-2'>{row[1]}</td>
+                            <td className='px-4 py-2 text-muted-foreground'>{row[2]}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  <Callout type='warn'>
+                    <strong>{t('Latency:')}</strong>{' '}
+                    {t(
+                      'audit adds ~10–30 s synchronous wait before /v1/video/generations returns the task_id. Plan client timeouts accordingly. The video generation itself happens after the gateway has substituted the asset:// URI, so it is unaffected.',
+                    )}
+                  </Callout>
+                  <Callout type='info'>
+                    <strong>{t('Op note:')}</strong>{' '}
+                    {t(
+                      'this feature requires ARK_AK / ARK_SK and (when callers send base64) COS_BUCKET / COS_SECRET_ID / COS_SECRET_KEY in the gateway env. ARK_ASSETS_PROJECT must match the project of the API key the seedance channel uses, or the asset:// reference will not be findable at inference time.',
                     )}
                   </Callout>
                 </Section>

--- a/web/default/src/features/docs/index.tsx
+++ b/web/default/src/features/docs/index.tsx
@@ -1375,9 +1375,9 @@ export function Docs() {
                   </Callout>
                   <Callout type='warn'>
                     <strong>{t('Real-person reference image?')}</strong>{' '}
-                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>{' '}
+                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>
                     {t(
-                      'so the gateway sends the image to ARK\'s asset library audit first and substitutes asset://<id> upstream. Without this flag a real-person photo will trip Seedance\'s privacy filter and the request fails outright. Adds ~10–30 s before task_id is returned.'
+                      ', otherwise the request will be rejected by the upstream privacy filter. Adds ~10–30 s before task_id is returned.'
                     )}
                   </Callout>
                 </Section>
@@ -1401,9 +1401,9 @@ export function Docs() {
                   </p>
                   <Callout type='warn'>
                     <strong>{t('Real-person reference image?')}</strong>{' '}
-                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>{' '}
+                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>
                     {t(
-                      'so the gateway sends the image to ARK\'s asset library audit first and substitutes asset://<id> upstream. Without this flag a real-person photo will trip Seedance\'s privacy filter and the request fails outright. Adds ~10–30 s before task_id is returned.'
+                      ', otherwise the request will be rejected by the upstream privacy filter. Adds ~10–30 s before task_id is returned.'
                     )}
                   </Callout>
                 </Section>
@@ -1440,9 +1440,9 @@ export function Docs() {
                   </Callout>
                   <Callout type='warn'>
                     <strong>{t('Real-person reference image?')}</strong>{' '}
-                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>{' '}
+                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>
                     {t(
-                      'so the gateway sends the image to ARK\'s asset library audit first and substitutes asset://<id> upstream. Without this flag a real-person photo will trip Seedance\'s privacy filter and the request fails outright. Adds ~10–30 s before task_id is returned.'
+                      ', otherwise the request will be rejected by the upstream privacy filter. Adds ~10–30 s before task_id is returned.'
                     )}
                   </Callout>
                 </Section>
@@ -1467,9 +1467,9 @@ export function Docs() {
                   </p>
                   <Callout type='warn'>
                     <strong>{t('Real-person reference image?')}</strong>{' '}
-                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>{' '}
+                    {t('Add')} <K>"metadata": &#123; "audit_image": true &#125;</K>
                     {t(
-                      'so the gateway sends the image to ARK\'s asset library audit first and substitutes asset://<id> upstream. Without this flag a real-person photo will trip Seedance\'s privacy filter and the request fails outright. Adds ~10–30 s before task_id is returned.'
+                      ', otherwise the request will be rejected by the upstream privacy filter. Adds ~10–30 s before task_id is returned.'
                     )}
                   </Callout>
                 </Section>

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -4413,18 +4413,7 @@
     "Zhipu": "智谱",
     "Zhipu V4": "智谱 V4",
     "Zoom": "缩放",
-    "Image audit (audit_image)": "图片审核（audit_image）",
-    "When to enable:": "什么时候开：",
-    "How it works": "工作机制",
-    "OpenAI shape — public URL": "OpenAI 形式 — URL 透传",
-    "OpenAI shape — base64 (gateway uploads to COS)": "OpenAI 形式 — base64（网关代上传 COS）",
-    "Volcano Ark SDK shape": "火山方舟 SDK 形式",
-    "Parameter reference": "参数说明",
-    "Failure shapes": "错误码",
-    "When": "触发场景",
-    "What to do": "处理建议",
-    "Latency:": "延迟：",
-    "Op note:": "运维注意：",
-    "Each entry may be:": "支持以下入参："
+    "Real-person reference image?": "图片里是真人 / 人脸？",
+    "so the gateway sends the image to ARK's asset library audit first and substitutes asset://<id> upstream. Without this flag a real-person photo will trip Seedance's privacy filter and the request fails outright. Adds ~10–30 s before task_id is returned.": "网关会先把图片送 ARK 资产库审核、再把上游请求里的 image_url 换成 asset://<id>。不加这个开关时，真人照片会被 Seedance 的隐私检测直接拦掉。开启后 task_id 返回会延迟约 10–30 秒。"
   }
 }

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -1794,7 +1794,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "相关项目",
     "footer.defaultCopyright": "版权所有。",
-    "footer.new\u0061pi.projectAttributionSuffix": "版权所有，由项目贡献者设计与开发。",
+    "footer.newapi.projectAttributionSuffix": "版权所有，由项目贡献者设计与开发。",
     "for balance changes.": "页可看到余额变化。",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "对于 2025 年 5 月 10 日之后添加的渠道，在部署时无需从模型名称中移除 \".\"",
     "for full attribution.": "查看完整归属说明。",
@@ -4412,6 +4412,19 @@
     "Your Turnstile site key": "您的 Turnstile 站点密钥",
     "Zhipu": "智谱",
     "Zhipu V4": "智谱 V4",
-    "Zoom": "缩放"
+    "Zoom": "缩放",
+    "Image audit (audit_image)": "图片审核（audit_image）",
+    "When to enable:": "什么时候开：",
+    "How it works": "工作机制",
+    "OpenAI shape — public URL": "OpenAI 形式 — URL 透传",
+    "OpenAI shape — base64 (gateway uploads to COS)": "OpenAI 形式 — base64（网关代上传 COS）",
+    "Volcano Ark SDK shape": "火山方舟 SDK 形式",
+    "Parameter reference": "参数说明",
+    "Failure shapes": "错误码",
+    "When": "触发场景",
+    "What to do": "处理建议",
+    "Latency:": "延迟：",
+    "Op note:": "运维注意：",
+    "Each entry may be:": "支持以下入参："
   }
 }

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -4414,6 +4414,6 @@
     "Zhipu V4": "智谱 V4",
     "Zoom": "缩放",
     "Real-person reference image?": "图片里是真人 / 人脸？",
-    "so the gateway sends the image to ARK's asset library audit first and substitutes asset://<id> upstream. Without this flag a real-person photo will trip Seedance's privacy filter and the request fails outright. Adds ~10–30 s before task_id is returned.": "网关会先把图片送 ARK 资产库审核、再把上游请求里的 image_url 换成 asset://<id>。不加这个开关时，真人照片会被 Seedance 的隐私检测直接拦掉。开启后 task_id 返回会延迟约 10–30 秒。"
+    ", otherwise the request will be rejected by the upstream privacy filter. Adds ~10–30 s before task_id is returned.": "，否则上游会因隐私检测拒绝请求。开启后 task_id 返回会延迟约 10–30 秒。"
   }
 }


### PR DESCRIPTION
## Summary

Add an opt-in audit step to the seedance video API. When the caller sets `metadata.audit_image=true`, every input image is run through Volcano ARK's asset library before the generation request goes upstream. Without the flag, behavior is byte-identical to today.

Why: real-person images that pass live moderation when fed via the asset library are blocked by sensitive-content detection when fed as a URL or base64 directly. This wraps the asset-audit dance into the relay so callers don't have to script it themselves.

## Flow

```
metadata.audit_image=true
        │
        ├─ image is http(s)://      → passthrough
        ├─ image is data:URI/base64 → decode → upload to Tencent COS → public URL
        └─ image is asset://<id>    → no-op (already audited)
                │
                v
        ARK CreateAsset(URL) → poll GetAsset → Active
                │
                v
        substitute asset://<id> back into the upstream payload → seedance
```

## Two API shapes, one flag

The `volcArkSubmitConvert` middleware already copies the entire raw Volcano-form body into `metadata`, so a single `req.Metadata[\"audit_image\"]` lookup covers both:

```bash
# OpenAI form
curl /v1/videos -d '{
  \"model\": \"doubao-seedance-2-0-fast-260128\",
  \"prompt\": \"...\",
  \"images\": [\"https://...\"],
  \"metadata\": { \"audit_image\": true }
}'

# Volcano form (Ark Python SDK)
curl /api/v3/contents/generations/tasks -d '{
  \"model\": \"doubao-seedance-2-0-fast-260128\",
  \"audit_image\": true,
  \"content\": [
    {\"type\": \"text\", \"text\": \"...\"},
    {\"type\": \"image_url\", \"image_url\": {\"url\": \"https://...\"}}
  ]
}'
```

## Verification (live, against the dev stack)

| Test | Result |
|---|---|
| URL passthrough → audit → seedance | task `task_iy1vWec...` ✅ completed |
| Base64 → COS upload → audit → seedance | task `task_knFBp7e...` ✅ in_progress, audit passed |
| No flag (regression) | task queued normally, identical to pre-PR |
| 1×1 PNG via base64 | upstream error \"Width must be between 300px and 6000px\" surfaced cleanly to the client |

## Implementation

- New package `service/imageaudit/` — `EnsureAuditedCached(ctx, src) → asset://<id>`. Owns ARK V4 signing, COS V5 signing, group find-or-create, polling, and a 30-min same-process result cache. Hand-rolled signing for both providers (no SDK dependency added).
- `relay/channel/task/doubao/adaptor.go` — `BuildRequestBody` walks `r.Content`, substitutes audited URIs when the flag is set. ~50 LOC of integration.
- Env wiring: 13 new variables in `.env.local.example` + forwarded in `docker-compose.local.yml`. `ARK_*` for the audit API, `COS_*` for the upload destination. Both groups are only required when the flag is used; without it the audit code path is never entered.

## Test plan

- [ ] Configure ARK_AK / ARK_SK with a project that has the asset library entitlement
- [ ] Configure COS_BUCKET / COS_SECRET_ID / COS_SECRET_KEY for a bucket whose objects are public-readable (the gateway sets `x-cos-acl: public-read` on upload)
- [ ] `docker compose ... up -d --build`
- [ ] POST /v1/videos with audit_image=true and a real-person photo URL → expect task to run (URL flows through audit, asset:// reference accepted by seedance)
- [ ] POST /v1/videos with audit_image=true and a `data:image/...;base64,...` payload → expect same outcome (COS upload step works)
- [ ] POST /v1/videos without audit_image → expect identical behavior to before this PR
- [ ] Submit a known-bad image (e.g. fully nude / extreme content) and expect the audit to fail with a clear `image_audit_failed` message rather than degrade to a normal 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)