### PR TITLE
[codex] add EPay-Alipay gateway

### DIFF
--- a/epay/.env.example
+++ b/epay/.env.example
@@ -1,0 +1,17 @@
+LISTEN_ADDR=:3001
+PUBLIC_BASE_URL=https://pay.kittyvibe.ai
+ORDER_STORE_PATH=/var/lib/epay-gateway/orders.json
+ALLOWED_NOTIFY_HOSTS=kittyvibe.ai
+
+EPAY_PID=kittyvibe
+EPAY_KEY=replace-with-openssl-rand-hex-32
+
+ALIPAY_APP_ID=2021000000000000
+ALIPAY_APP_PRIVATE_KEY=base64-encoded-pkcs8-private-key
+ALIPAY_PUBLIC_KEY=base64-encoded-alipay-public-key
+ALIPAY_SELLER_ID=
+ALIPAY_GATEWAY=https://openapi.alipay.com/gateway.do
+ALIPAY_SANDBOX=false
+
+HTTP_TIMEOUT=10s
+CALLBACK_RETRY_INTERVAL=30s

--- a/epay/.env.example
+++ b/epay/.env.example
@@ -9,7 +9,7 @@ EPAY_KEY=replace-with-openssl-rand-hex-32
 ALIPAY_APP_ID=2021000000000000
 ALIPAY_APP_PRIVATE_KEY=base64-encoded-pkcs8-private-key
 ALIPAY_PUBLIC_KEY=base64-encoded-alipay-public-key
-ALIPAY_SELLER_ID=
+ALIPAY_SELLER_ID=2088000000000000
 ALIPAY_GATEWAY=https://openapi.alipay.com/gateway.do
 ALIPAY_SANDBOX=false
 

--- a/epay/README.md
+++ b/epay/README.md
@@ -1,0 +1,56 @@
+# EPay-Alipay Gateway
+
+This folder owns the minimal EPay-compatible proxy for kittyvibe.ai.
+
+The gateway lets the main New API application keep using its existing EPay integration while the actual settlement goes through an approved Alipay web application.
+
+## Runtime Flow
+
+```text
+kittyvibe.ai New API
+  -> pay.kittyvibe.ai /submit.php
+  -> Alipay alipay.trade.page.pay
+  -> pay.kittyvibe.ai /alipay/notify
+  -> kittyvibe.ai /api/user/epay/notify
+```
+
+## Boundaries
+
+- New API stores only `EpayId` and `EpayKey`.
+- This gateway stores Alipay AppID, app private key, Alipay public key, and seller ID.
+- Alipay never calls New API directly.
+- New API never stores Alipay private keys.
+
+## New API Configuration
+
+```text
+ServerAddress = https://kittyvibe.ai
+PayAddress = https://pay.kittyvibe.ai
+EpayId = kittyvibe
+EpayKey = <same value as gateway EPAY_KEY>
+PayMethods = [{"name":"支付宝","type":"alipay","color":"#1677FF"}]
+CustomCallbackAddress = empty
+```
+
+## Gateway Environment
+
+```text
+EPAY_PID=kittyvibe
+EPAY_KEY=<openssl rand -hex 32>
+PUBLIC_BASE_URL=https://pay.kittyvibe.ai
+ALLOWED_NOTIFY_HOSTS=kittyvibe.ai
+ALIPAY_APP_ID=202100...
+ALIPAY_APP_PRIVATE_KEY=<PEM or base64 DER>
+ALIPAY_PUBLIC_KEY=<PEM or base64 DER>
+ALIPAY_SELLER_ID=<optional seller id>
+ALIPAY_GATEWAY=https://openapi.alipay.com/gateway.do
+ORDER_STORE_PATH=/var/lib/epay-gateway/orders.json
+LISTEN_ADDR=:3001
+```
+
+Run locally:
+
+```bash
+go test ./epay
+go run ./epay
+```

--- a/epay/README.md
+++ b/epay/README.md
@@ -42,11 +42,14 @@ ALLOWED_NOTIFY_HOSTS=kittyvibe.ai
 ALIPAY_APP_ID=202100...
 ALIPAY_APP_PRIVATE_KEY=<PEM or base64 DER>
 ALIPAY_PUBLIC_KEY=<PEM or base64 DER>
-ALIPAY_SELLER_ID=<optional seller id>
+ALIPAY_SELLER_ID=<required seller id in production>
 ALIPAY_GATEWAY=https://openapi.alipay.com/gateway.do
 ORDER_STORE_PATH=/var/lib/epay-gateway/orders.json
 LISTEN_ADDR=:3001
 ```
+
+`ALIPAY_SELLER_ID` may only be empty when `ALIPAY_SANDBOX=true`.
+Keep the gateway bound behind the reverse proxy and enable edge/WAF rate limiting for `POST /alipay/notify` and `POST /submit.php`.
 
 Run locally:
 

--- a/epay/alipay_client.go
+++ b/epay/alipay_client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/rsa"
 	"fmt"
 	"html"
 	"net/url"
@@ -12,12 +13,17 @@ import (
 const alipayPagePayMethod = "alipay.trade.page.pay"
 
 type AlipayClient struct {
-	cfg Config
-	now func() time.Time
+	cfg        Config
+	privateKey *rsa.PrivateKey
+	now        func() time.Time
 }
 
 func NewAlipayClient(cfg Config) *AlipayClient {
 	return &AlipayClient{cfg: cfg, now: time.Now}
+}
+
+func NewAlipayClientWithKey(cfg Config, privateKey *rsa.PrivateKey) *AlipayClient {
+	return &AlipayClient{cfg: cfg, privateKey: privateKey, now: time.Now}
 }
 
 func (c *AlipayClient) PagePayParams(order *Order) (map[string]string, error) {
@@ -44,7 +50,12 @@ func (c *AlipayClient) PagePayParams(order *Order) (map[string]string, error) {
 		"biz_content": string(bizContent),
 	}
 
-	signature, err := signAlipayParams(params, c.cfg.AlipayAppPrivateKey)
+	var signature string
+	if c.privateKey != nil {
+		signature, err = signAlipayParamsWithKey(params, c.privateKey)
+	} else {
+		signature, err = signAlipayParams(params, c.cfg.AlipayAppPrivateKey)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/epay/alipay_client.go
+++ b/epay/alipay_client.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"html"
+	"net/url"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+const alipayPagePayMethod = "alipay.trade.page.pay"
+
+type AlipayClient struct {
+	cfg Config
+	now func() time.Time
+}
+
+func NewAlipayClient(cfg Config) *AlipayClient {
+	return &AlipayClient{cfg: cfg, now: time.Now}
+}
+
+func (c *AlipayClient) PagePayParams(order *Order) (map[string]string, error) {
+	bizContent, err := common.Marshal(map[string]string{
+		"out_trade_no": order.OutTradeNo,
+		"product_code": "FAST_INSTANT_TRADE_PAY",
+		"total_amount": order.Amount,
+		"subject":      order.Subject,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal Alipay biz_content: %w", err)
+	}
+
+	params := map[string]string{
+		"app_id":      c.cfg.AlipayAppID,
+		"method":      alipayPagePayMethod,
+		"format":      "JSON",
+		"charset":     "utf-8",
+		"sign_type":   "RSA2",
+		"timestamp":   c.now().Format("2006-01-02 15:04:05"),
+		"version":     "1.0",
+		"notify_url":  stringsJoinURL(c.cfg.PublicBaseURL, "/alipay/notify"),
+		"return_url":  stringsJoinURL(c.cfg.PublicBaseURL, "/alipay/return"),
+		"biz_content": string(bizContent),
+	}
+
+	signature, err := signAlipayParams(params, c.cfg.AlipayAppPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	params["sign"] = signature
+	return params, nil
+}
+
+func (c *AlipayClient) PagePayForm(order *Order) (string, error) {
+	params, err := c.PagePayParams(order)
+	if err != nil {
+		return "", err
+	}
+	return renderAutoSubmitForm(c.cfg.AlipayGateway, params), nil
+}
+
+func renderAutoSubmitForm(action string, params map[string]string) string {
+	form := "<!doctype html><html><head><meta charset=\"utf-8\"><title>Redirecting to Alipay</title></head><body>"
+	form += "<form id=\"alipaysubmit\" name=\"alipaysubmit\" action=\"" + html.EscapeString(action) + "\" method=\"POST\">"
+	for key, value := range params {
+		form += "<input type=\"hidden\" name=\"" + html.EscapeString(key) + "\" value=\"" + html.EscapeString(value) + "\"/>"
+	}
+	form += "</form><script>document.getElementById('alipaysubmit').submit();</script></body></html>"
+	return form
+}
+
+func stringsJoinURL(base string, path string) string {
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return base + path
+	}
+	parsed.Path = path
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}

--- a/epay/alipay_client_test.go
+++ b/epay/alipay_client_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlipayPagePayParamsAreSignedAndContainGatewayCallbacks(t *testing.T) {
+	cfg := validTestConfig(t)
+	client := NewAlipayClient(cfg)
+	client.now = func() time.Time {
+		return time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC)
+	}
+	order := &Order{
+		OutTradeNo: "USR1NOabc",
+		Subject:    "TUC10",
+		Amount:     "7.30",
+	}
+
+	params, err := client.PagePayParams(order)
+	require.NoError(t, err)
+
+	require.Equal(t, "2021000000000000", params["app_id"])
+	require.Equal(t, alipayPagePayMethod, params["method"])
+	require.Equal(t, "https://pay.kittyvibe.ai/alipay/notify", params["notify_url"])
+	require.Equal(t, "https://pay.kittyvibe.ai/alipay/return", params["return_url"])
+	require.Contains(t, params["biz_content"], `"out_trade_no":"USR1NOabc"`)
+	require.Contains(t, params["biz_content"], `"total_amount":"7.30"`)
+	require.NotEmpty(t, params["sign"])
+}

--- a/epay/alipay_crypto.go
+++ b/epay/alipay_crypto.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+func normalizeRSAPrivateKey(raw string) (string, error) {
+	return normalizePEMKey(raw, "PRIVATE KEY", "RSA PRIVATE KEY")
+}
+
+func normalizeRSAPublicKey(raw string) (string, error) {
+	return normalizePEMKey(raw, "PUBLIC KEY", "RSA PUBLIC KEY")
+}
+
+func normalizePEMKey(raw string, pkcs8Type string, pkcs1Type string) (string, error) {
+	normalized := strings.TrimSpace(strings.ReplaceAll(raw, `\n`, "\n"))
+	if normalized == "" {
+		return "", fmt.Errorf("%s is empty", strings.ToLower(pkcs8Type))
+	}
+	if strings.Contains(normalized, "BEGIN ") {
+		block, _ := pem.Decode([]byte(normalized))
+		if block == nil {
+			return "", fmt.Errorf("invalid PEM encoded %s", strings.ToLower(pkcs8Type))
+		}
+		return string(pem.EncodeToMemory(block)), nil
+	}
+
+	der, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(normalized, "\n", ""))
+	if err != nil {
+		return "", fmt.Errorf("invalid base64 encoded %s: %w", strings.ToLower(pkcs8Type), err)
+	}
+
+	pemType := pkcs8Type
+	if pkcs8Type == "PRIVATE KEY" {
+		if _, err := x509.ParsePKCS8PrivateKey(der); err != nil {
+			if _, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+				pemType = pkcs1Type
+			} else {
+				return "", fmt.Errorf("invalid RSA private key")
+			}
+		}
+	} else {
+		if _, err := x509.ParsePKIXPublicKey(der); err != nil {
+			if _, err := x509.ParsePKCS1PublicKey(der); err == nil {
+				pemType = pkcs1Type
+			} else {
+				return "", fmt.Errorf("invalid RSA public key")
+			}
+		}
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: pemType, Bytes: der})), nil
+}
+
+func parseRSAPrivateKey(raw string) (*rsa.PrivateKey, error) {
+	keyPEM, err := normalizeRSAPrivateKey(raw)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode([]byte(keyPEM))
+	if block == nil {
+		return nil, fmt.Errorf("invalid RSA private key PEM")
+	}
+	switch block.Type {
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKCS#8 private key: %w", err)
+		}
+		parsed, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("private key is not RSA")
+		}
+		return parsed, nil
+	case "RSA PRIVATE KEY":
+		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKCS#1 private key: %w", err)
+		}
+		return key, nil
+	default:
+		return nil, fmt.Errorf("unsupported private key type: %s", block.Type)
+	}
+}
+
+func parseRSAPublicKey(raw string) (*rsa.PublicKey, error) {
+	keyPEM, err := normalizeRSAPublicKey(raw)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode([]byte(keyPEM))
+	if block == nil {
+		return nil, fmt.Errorf("invalid RSA public key PEM")
+	}
+	switch block.Type {
+	case "PUBLIC KEY":
+		key, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKIX public key: %w", err)
+		}
+		parsed, ok := key.(*rsa.PublicKey)
+		if !ok {
+			return nil, fmt.Errorf("public key is not RSA")
+		}
+		return parsed, nil
+	case "RSA PUBLIC KEY":
+		key, err := x509.ParsePKCS1PublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKCS#1 public key: %w", err)
+		}
+		return key, nil
+	default:
+		return nil, fmt.Errorf("unsupported public key type: %s", block.Type)
+	}
+}
+
+func alipaySigningContent(params map[string]string) string {
+	keys := make([]string, 0, len(params))
+	for k, v := range params {
+		if k == "sign" || k == "sign_type" || v == "" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+params[k])
+	}
+	return strings.Join(parts, "&")
+}
+
+func signAlipayParams(params map[string]string, privateKeyRaw string) (string, error) {
+	privateKey, err := parseRSAPrivateKey(privateKeyRaw)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256([]byte(alipaySigningContent(params)))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("sign Alipay params: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(signature), nil
+}
+
+func verifyAlipayParams(values url.Values, publicKeyRaw string) error {
+	signatureRaw := values.Get("sign")
+	if signatureRaw == "" {
+		return fmt.Errorf("missing Alipay sign")
+	}
+	params := map[string]string{}
+	for key, vals := range values {
+		if len(vals) > 0 {
+			params[key] = vals[0]
+		}
+	}
+	publicKey, err := parseRSAPublicKey(publicKeyRaw)
+	if err != nil {
+		return err
+	}
+	signature, err := base64.StdEncoding.DecodeString(signatureRaw)
+	if err != nil {
+		return fmt.Errorf("decode Alipay sign: %w", err)
+	}
+	digest := sha256.Sum256([]byte(alipaySigningContent(params)))
+	if err := rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, digest[:], signature); err != nil {
+		return fmt.Errorf("verify Alipay sign: %w", err)
+	}
+	return nil
+}

--- a/epay/alipay_crypto.go
+++ b/epay/alipay_crypto.go
@@ -124,6 +124,23 @@ func parseRSAPublicKey(raw string) (*rsa.PublicKey, error) {
 	}
 }
 
+type AlipayKeyPair struct {
+	Private *rsa.PrivateKey
+	Public  *rsa.PublicKey
+}
+
+func NewAlipayKeyPair(cfg Config) (*AlipayKeyPair, error) {
+	privateKey, err := parseRSAPrivateKey(cfg.AlipayAppPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse Alipay app private key: %w", err)
+	}
+	publicKey, err := parseRSAPublicKey(cfg.AlipayPublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse Alipay public key: %w", err)
+	}
+	return &AlipayKeyPair{Private: privateKey, Public: publicKey}, nil
+}
+
 func alipaySigningContent(params map[string]string) string {
 	keys := make([]string, 0, len(params))
 	for k, v := range params {
@@ -146,6 +163,13 @@ func signAlipayParams(params map[string]string, privateKeyRaw string) (string, e
 	if err != nil {
 		return "", err
 	}
+	return signAlipayParamsWithKey(params, privateKey)
+}
+
+func signAlipayParamsWithKey(params map[string]string, privateKey *rsa.PrivateKey) (string, error) {
+	if privateKey == nil {
+		return "", fmt.Errorf("missing Alipay private key")
+	}
 	digest := sha256.Sum256([]byte(alipaySigningContent(params)))
 	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, digest[:])
 	if err != nil {
@@ -155,6 +179,17 @@ func signAlipayParams(params map[string]string, privateKeyRaw string) (string, e
 }
 
 func verifyAlipayParams(values url.Values, publicKeyRaw string) error {
+	publicKey, err := parseRSAPublicKey(publicKeyRaw)
+	if err != nil {
+		return err
+	}
+	return verifyAlipayParamsWithKey(values, publicKey)
+}
+
+func verifyAlipayParamsWithKey(values url.Values, publicKey *rsa.PublicKey) error {
+	if publicKey == nil {
+		return fmt.Errorf("missing Alipay public key")
+	}
 	signatureRaw := values.Get("sign")
 	if signatureRaw == "" {
 		return fmt.Errorf("missing Alipay sign")
@@ -164,10 +199,6 @@ func verifyAlipayParams(values url.Values, publicKeyRaw string) error {
 		if len(vals) > 0 {
 			params[key] = vals[0]
 		}
-	}
-	publicKey, err := parseRSAPublicKey(publicKeyRaw)
-	if err != nil {
-		return err
 	}
 	signature, err := base64.StdEncoding.DecodeString(signatureRaw)
 	if err != nil {

--- a/epay/alipay_notify.go
+++ b/epay/alipay_notify.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/rsa"
 	"fmt"
 	"net/url"
 )
@@ -16,10 +17,18 @@ type AlipayNotification struct {
 }
 
 func VerifyAlipayNotification(values url.Values, cfg Config) (*AlipayNotification, error) {
+	publicKey, err := parseRSAPublicKey(cfg.AlipayPublicKey)
+	if err != nil {
+		return nil, err
+	}
+	return VerifyAlipayNotificationWithKey(values, cfg, publicKey)
+}
+
+func VerifyAlipayNotificationWithKey(values url.Values, cfg Config, publicKey *rsa.PublicKey) (*AlipayNotification, error) {
 	if values.Get("sign_type") != "RSA2" {
 		return nil, fmt.Errorf("unsupported Alipay sign_type")
 	}
-	if err := verifyAlipayParams(values, cfg.AlipayPublicKey); err != nil {
+	if err := verifyAlipayParamsWithKey(values, publicKey); err != nil {
 		return nil, err
 	}
 	notification := &AlipayNotification{

--- a/epay/alipay_notify.go
+++ b/epay/alipay_notify.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type AlipayNotification struct {
+	AppID       string
+	SellerID    string
+	OutTradeNo  string
+	TradeNo     string
+	TradeStatus string
+	TotalAmount string
+	Subject     string
+}
+
+func VerifyAlipayNotification(values url.Values, cfg Config) (*AlipayNotification, error) {
+	if values.Get("sign_type") != "RSA2" {
+		return nil, fmt.Errorf("unsupported Alipay sign_type")
+	}
+	if err := verifyAlipayParams(values, cfg.AlipayPublicKey); err != nil {
+		return nil, err
+	}
+	notification := &AlipayNotification{
+		AppID:       values.Get("app_id"),
+		SellerID:    values.Get("seller_id"),
+		OutTradeNo:  values.Get("out_trade_no"),
+		TradeNo:     values.Get("trade_no"),
+		TradeStatus: values.Get("trade_status"),
+		TotalAmount: values.Get("total_amount"),
+		Subject:     values.Get("subject"),
+	}
+	if notification.AppID != cfg.AlipayAppID {
+		return nil, fmt.Errorf("Alipay app_id mismatch")
+	}
+	if cfg.AlipaySellerID != "" && notification.SellerID != cfg.AlipaySellerID {
+		return nil, fmt.Errorf("Alipay seller_id mismatch")
+	}
+	if notification.OutTradeNo == "" {
+		return nil, fmt.Errorf("missing Alipay out_trade_no")
+	}
+	if notification.TotalAmount == "" {
+		return nil, fmt.Errorf("missing Alipay total_amount")
+	}
+	return notification, nil
+}
+
+func (n *AlipayNotification) IsPaid() bool {
+	return n.TradeStatus == "TRADE_SUCCESS" || n.TradeStatus == "TRADE_FINISHED"
+}

--- a/epay/config.go
+++ b/epay/config.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultListenAddr            = ":3001"
+	defaultAlipayGateway         = "https://openapi.alipay.com/gateway.do"
+	defaultAlipaySandboxGateway  = "https://openapi-sandbox.dl.alipaydev.com/gateway.do"
+	defaultOrderStorePath        = "epay-orders.json"
+	defaultAllowedNotifyHost     = "kittyvibe.ai"
+	defaultCallbackRetryInterval = 30 * time.Second
+	defaultHTTPTimeout           = 10 * time.Second
+)
+
+type Config struct {
+	ListenAddr            string
+	PublicBaseURL         string
+	EPayPID               string
+	EPayKey               string
+	AllowedNotifyHosts    map[string]struct{}
+	AlipayAppID           string
+	AlipayAppPrivateKey   string
+	AlipayPublicKey       string
+	AlipaySellerID        string
+	AlipayGateway         string
+	OrderStorePath        string
+	HTTPTimeout           time.Duration
+	CallbackRetryInterval time.Duration
+}
+
+func LoadConfigFromEnv() (Config, error) {
+	sandbox := parseBoolEnv("ALIPAY_SANDBOX", false)
+	alipayGateway := defaultAlipayGateway
+	if sandbox {
+		alipayGateway = defaultAlipaySandboxGateway
+	}
+
+	cfg := Config{
+		ListenAddr:            getenvDefault("LISTEN_ADDR", defaultListenAddr),
+		PublicBaseURL:         strings.TrimRight(strings.TrimSpace(os.Getenv("PUBLIC_BASE_URL")), "/"),
+		EPayPID:               strings.TrimSpace(os.Getenv("EPAY_PID")),
+		EPayKey:               strings.TrimSpace(os.Getenv("EPAY_KEY")),
+		AllowedNotifyHosts:    parseHostSet(getenvDefault("ALLOWED_NOTIFY_HOSTS", defaultAllowedNotifyHost)),
+		AlipayAppID:           strings.TrimSpace(os.Getenv("ALIPAY_APP_ID")),
+		AlipayAppPrivateKey:   strings.TrimSpace(os.Getenv("ALIPAY_APP_PRIVATE_KEY")),
+		AlipayPublicKey:       strings.TrimSpace(os.Getenv("ALIPAY_PUBLIC_KEY")),
+		AlipaySellerID:        strings.TrimSpace(os.Getenv("ALIPAY_SELLER_ID")),
+		AlipayGateway:         strings.TrimRight(getenvDefault("ALIPAY_GATEWAY", alipayGateway), "/"),
+		OrderStorePath:        getenvDefault("ORDER_STORE_PATH", defaultOrderStorePath),
+		HTTPTimeout:           parseDurationEnv("HTTP_TIMEOUT", defaultHTTPTimeout),
+		CallbackRetryInterval: parseDurationEnv("CALLBACK_RETRY_INTERVAL", defaultCallbackRetryInterval),
+	}
+	return cfg, cfg.Validate()
+}
+
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.PublicBaseURL) == "" {
+		return fmt.Errorf("PUBLIC_BASE_URL is required")
+	}
+	if parsed, err := url.Parse(c.PublicBaseURL); err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return fmt.Errorf("PUBLIC_BASE_URL must be an https URL")
+	}
+	if strings.TrimSpace(c.EPayPID) == "" {
+		return fmt.Errorf("EPAY_PID is required")
+	}
+	if strings.TrimSpace(c.EPayKey) == "" {
+		return fmt.Errorf("EPAY_KEY is required")
+	}
+	if strings.TrimSpace(c.AlipayAppID) == "" {
+		return fmt.Errorf("ALIPAY_APP_ID is required")
+	}
+	if strings.TrimSpace(c.AlipayAppPrivateKey) == "" {
+		return fmt.Errorf("ALIPAY_APP_PRIVATE_KEY is required")
+	}
+	if strings.TrimSpace(c.AlipayPublicKey) == "" {
+		return fmt.Errorf("ALIPAY_PUBLIC_KEY is required")
+	}
+	if parsed, err := url.Parse(c.AlipayGateway); err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return fmt.Errorf("ALIPAY_GATEWAY must be an https URL")
+	}
+	if len(c.AllowedNotifyHosts) == 0 {
+		return fmt.Errorf("ALLOWED_NOTIFY_HOSTS must include at least one host")
+	}
+	return nil
+}
+
+func (c Config) IsAllowedCallbackURL(raw string) (*url.URL, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid callback URL")
+	}
+	if parsed.Scheme != "https" {
+		return nil, fmt.Errorf("callback URL must use https")
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if _, ok := c.AllowedNotifyHosts[host]; !ok {
+		return nil, fmt.Errorf("callback host %q is not allowed", host)
+	}
+	return parsed, nil
+}
+
+func getenvDefault(key string, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func parseHostSet(raw string) map[string]struct{} {
+	result := map[string]struct{}{}
+	for _, part := range strings.Split(raw, ",") {
+		host := strings.ToLower(strings.TrimSpace(part))
+		if host == "" {
+			continue
+		}
+		result[host] = struct{}{}
+	}
+	return result
+}
+
+func parseBoolEnv(key string, fallback bool) bool {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseBool(raw)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func parseDurationEnv(key string, fallback time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}

--- a/epay/config.go
+++ b/epay/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	AlipayAppPrivateKey   string
 	AlipayPublicKey       string
 	AlipaySellerID        string
+	AlipaySandbox         bool
 	AlipayGateway         string
 	OrderStorePath        string
 	HTTPTimeout           time.Duration
@@ -52,6 +53,7 @@ func LoadConfigFromEnv() (Config, error) {
 		AlipayAppPrivateKey:   strings.TrimSpace(os.Getenv("ALIPAY_APP_PRIVATE_KEY")),
 		AlipayPublicKey:       strings.TrimSpace(os.Getenv("ALIPAY_PUBLIC_KEY")),
 		AlipaySellerID:        strings.TrimSpace(os.Getenv("ALIPAY_SELLER_ID")),
+		AlipaySandbox:         sandbox,
 		AlipayGateway:         strings.TrimRight(getenvDefault("ALIPAY_GATEWAY", alipayGateway), "/"),
 		OrderStorePath:        getenvDefault("ORDER_STORE_PATH", defaultOrderStorePath),
 		HTTPTimeout:           parseDurationEnv("HTTP_TIMEOUT", defaultHTTPTimeout),
@@ -81,6 +83,9 @@ func (c Config) Validate() error {
 	}
 	if strings.TrimSpace(c.AlipayPublicKey) == "" {
 		return fmt.Errorf("ALIPAY_PUBLIC_KEY is required")
+	}
+	if !c.AlipaySandbox && strings.TrimSpace(c.AlipaySellerID) == "" {
+		return fmt.Errorf("ALIPAY_SELLER_ID is required unless ALIPAY_SANDBOX=true")
 	}
 	if parsed, err := url.Parse(c.AlipayGateway); err != nil || parsed.Scheme != "https" || parsed.Host == "" {
 		return fmt.Errorf("ALIPAY_GATEWAY must be an https URL")

--- a/epay/config_test.go
+++ b/epay/config_test.go
@@ -13,6 +13,22 @@ func TestConfigValidateRequiresHTTPSPublicBaseURL(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "PUBLIC_BASE_URL")
 }
 
+func TestConfigValidateRequiresSellerIDInProduction(t *testing.T) {
+	cfg := validTestConfig(t)
+	cfg.AlipaySellerID = ""
+	cfg.AlipaySandbox = false
+
+	require.ErrorContains(t, cfg.Validate(), "ALIPAY_SELLER_ID")
+}
+
+func TestConfigValidateAllowsMissingSellerIDInSandbox(t *testing.T) {
+	cfg := validTestConfig(t)
+	cfg.AlipaySellerID = ""
+	cfg.AlipaySandbox = true
+
+	require.NoError(t, cfg.Validate())
+}
+
 func TestConfigAllowsOnlyConfiguredCallbackHosts(t *testing.T) {
 	cfg := validTestConfig(t)
 

--- a/epay/config_test.go
+++ b/epay/config_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidateRequiresHTTPSPublicBaseURL(t *testing.T) {
+	cfg := validTestConfig(t)
+	cfg.PublicBaseURL = "http://pay.kittyvibe.ai"
+
+	require.ErrorContains(t, cfg.Validate(), "PUBLIC_BASE_URL")
+}
+
+func TestConfigAllowsOnlyConfiguredCallbackHosts(t *testing.T) {
+	cfg := validTestConfig(t)
+
+	_, err := cfg.IsAllowedCallbackURL("https://kittyvibe.ai/api/user/epay/notify")
+	require.NoError(t, err)
+
+	_, err = cfg.IsAllowedCallbackURL("https://evil.example/api/user/epay/notify")
+	require.ErrorContains(t, err, "not allowed")
+
+	_, err = cfg.IsAllowedCallbackURL("http://kittyvibe.ai/api/user/epay/notify")
+	require.ErrorContains(t, err, "https")
+}

--- a/epay/deploy/Caddyfile.example
+++ b/epay/deploy/Caddyfile.example
@@ -1,0 +1,3 @@
+pay.kittyvibe.ai {
+  reverse_proxy 127.0.0.1:3001
+}

--- a/epay/deploy/Caddyfile.example
+++ b/epay/deploy/Caddyfile.example
@@ -1,3 +1,7 @@
 pay.kittyvibe.ai {
+  request_body {
+    max_size 64KB
+  }
+
   reverse_proxy 127.0.0.1:3001
 }

--- a/epay/deploy/Dockerfile.example
+++ b/epay/deploy/Dockerfile.example
@@ -1,0 +1,12 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /src
+COPY . .
+RUN go build -o /out/epay-gateway ./epay
+
+FROM alpine:3.22
+RUN adduser -D -H epay-gateway
+USER epay-gateway
+WORKDIR /app
+COPY --from=builder /out/epay-gateway /app/epay-gateway
+EXPOSE 3001
+ENTRYPOINT ["/app/epay-gateway"]

--- a/epay/deploy/docker-compose.example.yml
+++ b/epay/deploy/docker-compose.example.yml
@@ -1,0 +1,16 @@
+services:
+  epay-gateway:
+    build:
+      context: ../..
+      dockerfile: epay/deploy/Dockerfile.example
+    image: kittyvibe-epay-gateway:local
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "127.0.0.1:3001:3001"
+    volumes:
+      - epay_gateway_data:/var/lib/epay-gateway
+
+volumes:
+  epay_gateway_data:

--- a/epay/deploy/epay-gateway.service.example
+++ b/epay/deploy/epay-gateway.service.example
@@ -1,0 +1,22 @@
+[Unit]
+Description=kittyvibe EPay-Alipay gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=epay-gateway
+Group=epay-gateway
+WorkingDirectory=/opt/aikanhub
+EnvironmentFile=/etc/epay-gateway.env
+ExecStart=/opt/aikanhub/epay-gateway
+Restart=always
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/epay-gateway
+
+[Install]
+WantedBy=multi-user.target

--- a/epay/epay_sign.go
+++ b/epay/epay_sign.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func SignEPayParams(params map[string]string, key string) string {
+	filtered := make(map[string]string, len(params))
+	for k, v := range params {
+		if k == "sign" || k == "sign_type" || v == "" {
+			continue
+		}
+		filtered[k] = v
+	}
+
+	keys := make([]string, 0, len(filtered))
+	for k := range filtered {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+filtered[k])
+	}
+
+	sum := md5.Sum([]byte(strings.Join(parts, "&") + key))
+	return fmt.Sprintf("%x", sum)
+}
+
+func AddEPaySignature(params map[string]string, key string) map[string]string {
+	signed := make(map[string]string, len(params)+2)
+	for k, v := range params {
+		signed[k] = v
+	}
+	signed["sign"] = SignEPayParams(signed, key)
+	signed["sign_type"] = "MD5"
+	return signed
+}
+
+func VerifyEPayParams(params map[string]string, key string) bool {
+	sign := params["sign"]
+	if sign == "" {
+		return false
+	}
+	expected := SignEPayParams(params, key)
+	return hmac.Equal([]byte(sign), []byte(expected))
+}

--- a/epay/epay_sign_test.go
+++ b/epay/epay_sign_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Calcium-Ion/go-epay/epay"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignEPayParamsMatchesGoEpay(t *testing.T) {
+	params := map[string]string{
+		"pid":          "kittyvibe",
+		"type":         "alipay",
+		"out_trade_no": "USR1NOabc",
+		"notify_url":   "https://kittyvibe.ai/api/user/epay/notify",
+		"return_url":   "https://kittyvibe.ai/console/log",
+		"name":         "TUC10",
+		"money":        "7.30",
+		"device":       "pc",
+		"sign_type":    "MD5",
+		"sign":         "",
+	}
+
+	got := AddEPaySignature(params, "secret")
+	want := epay.GenerateParams(params, "secret")
+
+	require.Equal(t, want["sign"], got["sign"])
+	require.True(t, VerifyEPayParams(got, "secret"))
+	got["money"] = "7.31"
+	require.False(t, VerifyEPayParams(got, "secret"))
+}

--- a/epay/main.go
+++ b/epay/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		log.Fatalf("invalid config: %v", err)
+	}
+	store, err := NewFileOrderStore(cfg.OrderStorePath)
+	if err != nil {
+		log.Fatalf("open order store: %v", err)
+	}
+	gateway := NewGateway(cfg, store, log.Default())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go RunRetryWorker(ctx, gateway, cfg.CallbackRetryInterval, defaultMaxCallbackAttempts)
+
+	server := &http.Server{
+		Addr:              cfg.ListenAddr,
+		Handler:           gateway.Routes(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	log.Printf("EPay-Alipay gateway listening on %s", cfg.ListenAddr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("server failed: %v", err)
+	}
+}

--- a/epay/main.go
+++ b/epay/main.go
@@ -10,6 +10,13 @@ import (
 	"time"
 )
 
+const (
+	defaultReadHeaderTimeout = 5 * time.Second
+	defaultReadTimeout       = 10 * time.Second
+	defaultWriteTimeout      = 15 * time.Second
+	defaultIdleTimeout       = 60 * time.Second
+)
+
 func main() {
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
@@ -19,17 +26,16 @@ func main() {
 	if err != nil {
 		log.Fatalf("open order store: %v", err)
 	}
-	gateway := NewGateway(cfg, store, log.Default())
+	gateway, err := NewGateway(cfg, store, log.Default())
+	if err != nil {
+		log.Fatalf("create gateway: %v", err)
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	go RunRetryWorker(ctx, gateway, cfg.CallbackRetryInterval, defaultMaxCallbackAttempts)
 
-	server := &http.Server{
-		Addr:              cfg.ListenAddr,
-		Handler:           gateway.Routes(),
-		ReadHeaderTimeout: 5 * time.Second,
-	}
+	server := newHTTPServer(cfg, gateway.Routes())
 	go func() {
 		<-ctx.Done()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -40,5 +46,17 @@ func main() {
 	log.Printf("EPay-Alipay gateway listening on %s", cfg.ListenAddr)
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("server failed: %v", err)
+	}
+}
+
+func newHTTPServer(cfg Config, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              cfg.ListenAddr,
+		Handler:           handler,
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
+		ReadTimeout:       defaultReadTimeout,
+		WriteTimeout:      defaultWriteTimeout,
+		IdleTimeout:       defaultIdleTimeout,
+		MaxHeaderBytes:    16 * 1024,
 	}
 }

--- a/epay/main_test.go
+++ b/epay/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPServerSetsDefensiveTimeouts(t *testing.T) {
+	cfg := validTestConfig(t)
+	server := newHTTPServer(cfg, http.NotFoundHandler())
+
+	require.Equal(t, cfg.ListenAddr, server.Addr)
+	require.Equal(t, defaultReadHeaderTimeout, server.ReadHeaderTimeout)
+	require.Equal(t, defaultReadTimeout, server.ReadTimeout)
+	require.Equal(t, defaultWriteTimeout, server.WriteTimeout)
+	require.Equal(t, defaultIdleTimeout, server.IdleTimeout)
+	require.Equal(t, 16*1024, server.MaxHeaderBytes)
+}

--- a/epay/newapi_callback.go
+++ b/epay/newapi_callback.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type CallbackSender struct {
+	PID    string
+	Key    string
+	Client *http.Client
+}
+
+func NewCallbackSender(cfg Config) *CallbackSender {
+	return &CallbackSender{
+		PID:    cfg.EPayPID,
+		Key:    cfg.EPayKey,
+		Client: &http.Client{Timeout: cfg.HTTPTimeout},
+	}
+}
+
+func (s *CallbackSender) Params(order *Order) map[string]string {
+	params := map[string]string{
+		"pid":          s.PID,
+		"type":         order.PaymentType,
+		"out_trade_no": order.OutTradeNo,
+		"trade_no":     order.AlipayTradeNo,
+		"name":         order.Subject,
+		"money":        order.Amount,
+		"trade_status": "TRADE_SUCCESS",
+	}
+	return AddEPaySignature(params, s.Key)
+}
+
+func (s *CallbackSender) Send(ctx context.Context, order *Order) error {
+	if order.NotifyURL == "" {
+		return fmt.Errorf("missing notify_url")
+	}
+	form := url.Values{}
+	for k, v := range s.Params(order) {
+		form.Set(k, v)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, order.NotifyURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 128))
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(string(body)) != "success" {
+		return fmt.Errorf("New API callback returned status=%d body=%q", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("New API callback returned non-2xx status=%d", resp.StatusCode)
+	}
+	return nil
+}
+
+func callbackContext(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}

--- a/epay/newapi_callback_test.go
+++ b/epay/newapi_callback_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallbackSenderRequiresSuccessBodyAnd2xxStatus(t *testing.T) {
+	cfg := validTestConfig(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	sender := NewCallbackSender(cfg)
+	order := &Order{
+		OutTradeNo:    "USR1NOabc",
+		PaymentType:   "alipay",
+		Subject:       "TUC10",
+		Amount:        "7.30",
+		AlipayTradeNo: "2026050722000000000001",
+		NotifyURL:     server.URL,
+	}
+
+	err := sender.Send(context.Background(), order)
+	require.ErrorContains(t, err, "non-2xx")
+}

--- a/epay/orders.go
+++ b/epay/orders.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+const (
+	OrderStatusCreated         = "created"
+	OrderStatusPaying          = "paying"
+	OrderStatusPaid            = "paid"
+	OrderStatusCallbackPending = "callback_pending"
+	OrderStatusCallbackSuccess = "callback_success"
+	OrderStatusCallbackFailed  = "callback_failed"
+)
+
+type Order struct {
+	OutTradeNo            string `json:"out_trade_no"`
+	PID                   string `json:"pid"`
+	PaymentType           string `json:"payment_type"`
+	Subject               string `json:"subject"`
+	Amount                string `json:"amount"`
+	NotifyURL             string `json:"notify_url"`
+	ReturnURL             string `json:"return_url"`
+	AlipayTradeNo         string `json:"alipay_trade_no,omitempty"`
+	Status                string `json:"status"`
+	CallbackAttempts      int    `json:"callback_attempts"`
+	LastCallbackError     string `json:"last_callback_error,omitempty"`
+	CreatedAt             int64  `json:"created_at"`
+	UpdatedAt             int64  `json:"updated_at"`
+	PaidAt                int64  `json:"paid_at,omitempty"`
+	CallbackSuccessAt     int64  `json:"callback_success_at,omitempty"`
+	LastCallbackAttemptAt int64  `json:"last_callback_attempt_at,omitempty"`
+}
+
+func (o *Order) SameRequest(other *Order) bool {
+	return o.OutTradeNo == other.OutTradeNo &&
+		o.PID == other.PID &&
+		o.PaymentType == other.PaymentType &&
+		o.Subject == other.Subject &&
+		o.Amount == other.Amount &&
+		o.NotifyURL == other.NotifyURL &&
+		o.ReturnURL == other.ReturnURL
+}
+
+type OrderStore interface {
+	UpsertFromSubmit(order *Order) (*Order, bool, error)
+	Find(outTradeNo string) (*Order, bool, error)
+	MarkPaying(outTradeNo string) error
+	MarkPaid(outTradeNo string, alipayTradeNo string) (*Order, bool, error)
+	RecordCallback(outTradeNo string, success bool, errText string) error
+	RetryableOrders(maxAttempts int) ([]*Order, error)
+}
+
+type FileOrderStore struct {
+	mu     sync.Mutex
+	path   string
+	orders map[string]*Order
+}
+
+func NewFileOrderStore(path string) (*FileOrderStore, error) {
+	store := &FileOrderStore{path: path, orders: map[string]*Order{}}
+	if err := store.load(); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *FileOrderStore) UpsertFromSubmit(order *Order) (*Order, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().Unix()
+	if existing, ok := s.orders[order.OutTradeNo]; ok {
+		if !existing.SameRequest(order) {
+			return nil, false, fmt.Errorf("order %s already exists with different fields", order.OutTradeNo)
+		}
+		return cloneOrder(existing), true, nil
+	}
+	order.Status = OrderStatusCreated
+	order.CreatedAt = now
+	order.UpdatedAt = now
+	s.orders[order.OutTradeNo] = cloneOrder(order)
+	if err := s.saveLocked(); err != nil {
+		return nil, false, err
+	}
+	return cloneOrder(order), false, nil
+}
+
+func (s *FileOrderStore) Find(outTradeNo string) (*Order, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	order, ok := s.orders[outTradeNo]
+	if !ok {
+		return nil, false, nil
+	}
+	return cloneOrder(order), true, nil
+}
+
+func (s *FileOrderStore) MarkPaying(outTradeNo string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	order, ok := s.orders[outTradeNo]
+	if !ok {
+		return fmt.Errorf("order %s not found", outTradeNo)
+	}
+	if order.Status == OrderStatusCreated {
+		order.Status = OrderStatusPaying
+		order.UpdatedAt = time.Now().Unix()
+		return s.saveLocked()
+	}
+	return nil
+}
+
+func (s *FileOrderStore) MarkPaid(outTradeNo string, alipayTradeNo string) (*Order, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	order, ok := s.orders[outTradeNo]
+	if !ok {
+		return nil, false, fmt.Errorf("order %s not found", outTradeNo)
+	}
+	if order.Status == OrderStatusCallbackSuccess {
+		return cloneOrder(order), false, nil
+	}
+	wasNewPayment := order.PaidAt == 0
+	now := time.Now().Unix()
+	order.Status = OrderStatusCallbackPending
+	order.AlipayTradeNo = alipayTradeNo
+	if order.PaidAt == 0 {
+		order.PaidAt = now
+	}
+	order.UpdatedAt = now
+	if err := s.saveLocked(); err != nil {
+		return nil, false, err
+	}
+	return cloneOrder(order), wasNewPayment, nil
+}
+
+func (s *FileOrderStore) RecordCallback(outTradeNo string, success bool, errText string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	order, ok := s.orders[outTradeNo]
+	if !ok {
+		return fmt.Errorf("order %s not found", outTradeNo)
+	}
+	now := time.Now().Unix()
+	order.CallbackAttempts++
+	order.LastCallbackAttemptAt = now
+	order.UpdatedAt = now
+	if success {
+		order.Status = OrderStatusCallbackSuccess
+		order.LastCallbackError = ""
+		order.CallbackSuccessAt = now
+	} else {
+		order.Status = OrderStatusCallbackFailed
+		order.LastCallbackError = errText
+	}
+	return s.saveLocked()
+}
+
+func (s *FileOrderStore) RetryableOrders(maxAttempts int) ([]*Order, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var orders []*Order
+	for _, order := range s.orders {
+		if (order.Status == OrderStatusCallbackPending || order.Status == OrderStatusCallbackFailed) &&
+			order.CallbackAttempts < maxAttempts {
+			orders = append(orders, cloneOrder(order))
+		}
+	}
+	return orders, nil
+}
+
+func (s *FileOrderStore) load() error {
+	if s.path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var orders map[string]*Order
+	if err := common.Unmarshal(data, &orders); err != nil {
+		return err
+	}
+	if orders != nil {
+		s.orders = orders
+	}
+	return nil
+}
+
+func (s *FileOrderStore) saveLocked() error {
+	if s.path == "" {
+		return nil
+	}
+	data, err := common.Marshal(s.orders)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}
+
+func cloneOrder(order *Order) *Order {
+	if order == nil {
+		return nil
+	}
+	cp := *order
+	return &cp
+}

--- a/epay/retry_worker.go
+++ b/epay/retry_worker.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+const defaultMaxCallbackAttempts = 20
+
+func RunRetryWorker(ctx context.Context, gateway *Gateway, interval time.Duration, maxAttempts int) {
+	if interval <= 0 {
+		interval = defaultCallbackRetryInterval
+	}
+	if maxAttempts <= 0 {
+		maxAttempts = defaultMaxCallbackAttempts
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := gateway.RetryPendingCallbacks(ctx, maxAttempts); err != nil {
+				log.Printf("retry callbacks failed: %v", err)
+			}
+		}
+	}
+}

--- a/epay/server.go
+++ b/epay/server.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rsa"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,25 +13,36 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+const maxFormBodyBytes int64 = 64 * 1024
+
 type Gateway struct {
-	cfg      Config
-	store    OrderStore
-	alipay   *AlipayClient
-	callback *CallbackSender
-	logger   *log.Logger
+	cfg             Config
+	store           OrderStore
+	alipay          *AlipayClient
+	alipayPublicKey *rsa.PublicKey
+	callback        *CallbackSender
+	logger          *log.Logger
 }
 
-func NewGateway(cfg Config, store OrderStore, logger *log.Logger) *Gateway {
+func NewGateway(cfg Config, store OrderStore, logger *log.Logger) (*Gateway, error) {
 	if logger == nil {
 		logger = log.Default()
 	}
-	return &Gateway{
-		cfg:      cfg,
-		store:    store,
-		alipay:   NewAlipayClient(cfg),
-		callback: NewCallbackSender(cfg),
-		logger:   logger,
+	if err := cfg.Validate(); err != nil {
+		return nil, err
 	}
+	keys, err := NewAlipayKeyPair(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Gateway{
+		cfg:             cfg,
+		store:           store,
+		alipay:          NewAlipayClientWithKey(cfg, keys.Private),
+		alipayPublicKey: keys.Public,
+		callback:        NewCallbackSender(cfg),
+		logger:          logger,
+	}, nil
 }
 
 func (g *Gateway) Routes() http.Handler {
@@ -51,8 +64,8 @@ func (g *Gateway) handleSubmit(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "invalid form", http.StatusBadRequest)
+	if err := parseLimitedForm(w, r); err != nil {
+		writeFormError(w, err, "invalid form")
 		return
 	}
 	params := firstFormValues(r.PostForm)
@@ -119,11 +132,15 @@ func (g *Gateway) handleAlipayNotify(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
+	if err := parseLimitedForm(w, r); err != nil {
+		if isRequestBodyTooLarge(err) {
+			http.Error(w, "request too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		_, _ = w.Write([]byte("fail"))
 		return
 	}
-	notification, err := VerifyAlipayNotification(r.PostForm, g.cfg)
+	notification, err := VerifyAlipayNotificationWithKey(r.PostForm, g.cfg, g.alipayPublicKey)
 	if err != nil {
 		g.logger.Printf("Alipay notify verify failed error=%v", err)
 		_, _ = w.Write([]byte("fail"))
@@ -188,6 +205,24 @@ func firstFormValues(values url.Values) map[string]string {
 		}
 	}
 	return params
+}
+
+func parseLimitedForm(w http.ResponseWriter, r *http.Request) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxFormBodyBytes)
+	return r.ParseForm()
+}
+
+func writeFormError(w http.ResponseWriter, err error, fallback string) {
+	if isRequestBodyTooLarge(err) {
+		http.Error(w, "request too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+	http.Error(w, fallback, http.StatusBadRequest)
+}
+
+func isRequestBodyTooLarge(err error) bool {
+	var maxBytesError *http.MaxBytesError
+	return errors.As(err, &maxBytesError)
 }
 
 func normalizeAmount(raw string) (string, error) {

--- a/epay/server.go
+++ b/epay/server.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+type Gateway struct {
+	cfg      Config
+	store    OrderStore
+	alipay   *AlipayClient
+	callback *CallbackSender
+	logger   *log.Logger
+}
+
+func NewGateway(cfg Config, store OrderStore, logger *log.Logger) *Gateway {
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &Gateway{
+		cfg:      cfg,
+		store:    store,
+		alipay:   NewAlipayClient(cfg),
+		callback: NewCallbackSender(cfg),
+		logger:   logger,
+	}
+}
+
+func (g *Gateway) Routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", g.handleHealth)
+	mux.HandleFunc("/submit.php", g.handleSubmit)
+	mux.HandleFunc("/alipay/notify", g.handleAlipayNotify)
+	mux.HandleFunc("/alipay/return", g.handleAlipayReturn)
+	return mux
+}
+
+func (g *Gateway) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func (g *Gateway) handleSubmit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+	params := firstFormValues(r.PostForm)
+	if params["pid"] != g.cfg.EPayPID {
+		http.Error(w, "invalid pid", http.StatusBadRequest)
+		return
+	}
+	if params["type"] != "alipay" {
+		http.Error(w, "unsupported payment type", http.StatusBadRequest)
+		return
+	}
+	if params["sign_type"] != "MD5" || !VerifyEPayParams(params, g.cfg.EPayKey) {
+		http.Error(w, "invalid sign", http.StatusBadRequest)
+		return
+	}
+	notifyURL, err := g.cfg.IsAllowedCallbackURL(params["notify_url"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	returnURL, err := g.cfg.IsAllowedCallbackURL(params["return_url"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	amount, err := normalizeAmount(params["money"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(params["out_trade_no"]) == "" || strings.TrimSpace(params["name"]) == "" {
+		http.Error(w, "missing order fields", http.StatusBadRequest)
+		return
+	}
+	order := &Order{
+		OutTradeNo:  params["out_trade_no"],
+		PID:         params["pid"],
+		PaymentType: params["type"],
+		Subject:     params["name"],
+		Amount:      amount,
+		NotifyURL:   notifyURL.String(),
+		ReturnURL:   returnURL.String(),
+	}
+	stored, _, err := g.store.UpsertFromSubmit(order)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	form, err := g.alipay.PagePayForm(stored)
+	if err != nil {
+		g.logger.Printf("create Alipay form failed order=%s error=%v", stored.OutTradeNo, err)
+		http.Error(w, "create payment failed", http.StatusInternalServerError)
+		return
+	}
+	if err := g.store.MarkPaying(stored.OutTradeNo); err != nil {
+		g.logger.Printf("mark paying failed order=%s error=%v", stored.OutTradeNo, err)
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(form))
+}
+
+func (g *Gateway) handleAlipayNotify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		_, _ = w.Write([]byte("fail"))
+		return
+	}
+	notification, err := VerifyAlipayNotification(r.PostForm, g.cfg)
+	if err != nil {
+		g.logger.Printf("Alipay notify verify failed error=%v", err)
+		_, _ = w.Write([]byte("fail"))
+		return
+	}
+	order, ok, err := g.store.Find(notification.OutTradeNo)
+	if err != nil || !ok {
+		g.logger.Printf("Alipay notify unknown order=%s error=%v", notification.OutTradeNo, err)
+		_, _ = w.Write([]byte("fail"))
+		return
+	}
+	if notification.TotalAmount != order.Amount {
+		g.logger.Printf("Alipay amount mismatch order=%s expected=%s got=%s", order.OutTradeNo, order.Amount, notification.TotalAmount)
+		_, _ = w.Write([]byte("fail"))
+		return
+	}
+	if !notification.IsPaid() {
+		g.logger.Printf("Alipay notify ignored order=%s status=%s", order.OutTradeNo, notification.TradeStatus)
+		_, _ = w.Write([]byte("success"))
+		return
+	}
+	paidOrder, shouldCallback, err := g.store.MarkPaid(order.OutTradeNo, notification.TradeNo)
+	if err != nil {
+		g.logger.Printf("mark paid failed order=%s error=%v", order.OutTradeNo, err)
+		_, _ = w.Write([]byte("fail"))
+		return
+	}
+	if shouldCallback {
+		g.processCallback(paidOrder)
+	}
+	_, _ = w.Write([]byte("success"))
+}
+
+func (g *Gateway) handleAlipayReturn(w http.ResponseWriter, r *http.Request) {
+	outTradeNo := r.URL.Query().Get("out_trade_no")
+	if outTradeNo != "" {
+		if order, ok, err := g.store.Find(outTradeNo); err == nil && ok && order.ReturnURL != "" {
+			http.Redirect(w, r, order.ReturnURL, http.StatusFound)
+			return
+		}
+	}
+	http.Redirect(w, r, "https://kittyvibe.ai/console/log", http.StatusFound)
+}
+
+func (g *Gateway) processCallback(order *Order) {
+	ctx, cancel := callbackContext(g.cfg.HTTPTimeout)
+	defer cancel()
+	err := g.callback.Send(ctx, order)
+	if err != nil {
+		g.logger.Printf("New API callback failed order=%s error=%v", order.OutTradeNo, err)
+		_ = g.store.RecordCallback(order.OutTradeNo, false, err.Error())
+		return
+	}
+	_ = g.store.RecordCallback(order.OutTradeNo, true, "")
+}
+
+func firstFormValues(values url.Values) map[string]string {
+	params := map[string]string{}
+	for key, value := range values {
+		if len(value) > 0 {
+			params[key] = value[0]
+		}
+	}
+	return params
+}
+
+func normalizeAmount(raw string) (string, error) {
+	amount, err := decimal.NewFromString(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid money")
+	}
+	if !amount.IsPositive() {
+		return "", fmt.Errorf("money must be positive")
+	}
+	if amount.Exponent() < -2 {
+		return "", fmt.Errorf("money supports at most two decimal places")
+	}
+	return amount.StringFixed(2), nil
+}
+
+func (g *Gateway) RetryPendingCallbacks(ctx context.Context, maxAttempts int) error {
+	orders, err := g.store.RetryableOrders(maxAttempts)
+	if err != nil {
+		return err
+	}
+	for _, order := range orders {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			g.processCallback(order)
+		}
+	}
+	return nil
+}

--- a/epay/server_test.go
+++ b/epay/server_test.go
@@ -14,7 +14,8 @@ func TestSubmitRejectsInvalidEPaySignature(t *testing.T) {
 	cfg := validTestConfig(t)
 	store, err := NewFileOrderStore(cfg.OrderStorePath)
 	require.NoError(t, err)
-	gateway := NewGateway(cfg, store, nil)
+	gateway, err := NewGateway(cfg, store, nil)
+	require.NoError(t, err)
 
 	form := signedEPayForm(cfg, nil)
 	form.Set("sign", "bad")
@@ -28,11 +29,40 @@ func TestSubmitRejectsInvalidEPaySignature(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "invalid sign")
 }
 
+func TestSubmitRejectsOversizedFormBody(t *testing.T) {
+	cfg := validTestConfig(t)
+	store, err := NewFileOrderStore(cfg.OrderStorePath)
+	require.NoError(t, err)
+	gateway, err := NewGateway(cfg, store, nil)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/submit.php", strings.NewReader("pid="+strings.Repeat("a", 70*1024)))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	gateway.Routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	require.Contains(t, rec.Body.String(), "request too large")
+}
+
+func TestGatewayRejectsInvalidAlipayKeysAtStartup(t *testing.T) {
+	cfg := validTestConfig(t)
+	cfg.AlipayPublicKey = "not-a-valid-key"
+	store, err := NewFileOrderStore(cfg.OrderStorePath)
+	require.NoError(t, err)
+
+	_, err = NewGateway(cfg, store, nil)
+
+	require.ErrorContains(t, err, "Alipay public key")
+}
+
 func TestSubmitAcceptsSignedOrderAndReturnsAlipayForm(t *testing.T) {
 	cfg := validTestConfig(t)
 	store, err := NewFileOrderStore(cfg.OrderStorePath)
 	require.NoError(t, err)
-	gateway := NewGateway(cfg, store, nil)
+	gateway, err := NewGateway(cfg, store, nil)
+	require.NoError(t, err)
 
 	form := signedEPayForm(cfg, nil)
 	req := httptest.NewRequest(http.MethodPost, "/submit.php", strings.NewReader(form.Encode()))
@@ -77,7 +107,8 @@ func TestAlipayNotifyCallbacksNewAPIOnce(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	gateway := NewGateway(cfg, store, nil)
+	gateway, err := NewGateway(cfg, store, nil)
+	require.NoError(t, err)
 	notify := signedAlipayNotify(t, cfg, nil)
 
 	for i := 0; i < 2; i++ {
@@ -112,7 +143,8 @@ func TestAlipayNotifyRejectsAmountMismatch(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	gateway := NewGateway(cfg, store, nil)
+	gateway, err := NewGateway(cfg, store, nil)
+	require.NoError(t, err)
 	notify := signedAlipayNotify(t, cfg, map[string]string{"total_amount": "7.31"})
 	req := httptest.NewRequest(http.MethodPost, "/alipay/notify", strings.NewReader(notify.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -126,4 +158,21 @@ func TestAlipayNotifyRejectsAmountMismatch(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, OrderStatusCreated, order.Status)
+}
+
+func TestAlipayNotifyRejectsOversizedFormBody(t *testing.T) {
+	cfg := validTestConfig(t)
+	store, err := NewFileOrderStore(cfg.OrderStorePath)
+	require.NoError(t, err)
+	gateway, err := NewGateway(cfg, store, nil)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/alipay/notify", strings.NewReader("sign="+strings.Repeat("a", 70*1024)))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	gateway.Routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	require.Contains(t, rec.Body.String(), "request too large")
 }

--- a/epay/server_test.go
+++ b/epay/server_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitRejectsInvalidEPaySignature(t *testing.T) {
+	cfg := validTestConfig(t)
+	store, err := NewFileOrderStore(cfg.OrderStorePath)
+	require.NoError(t, err)
+	gateway := NewGateway(cfg, store, nil)
+
+	form := signedEPayForm(cfg, nil)
+	form.Set("sign", "bad")
+	req := httptest.NewRequest(http.MethodPost, "/submit.php", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	gateway.Routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "invalid sign")
+}
+
+func TestSubmitAcceptsSignedOrderAndReturnsAlipayForm(t *testing.T) {
+	cfg := validTestConfig(t)
+	store, err := NewFileOrderStore(cfg.OrderStorePath)
+	require.NoError(t, err)
+	gateway := NewGateway(cfg, store, nil)
+
+	form := signedEPayForm(cfg, nil)
+	req := httptest.NewRequest(http.MethodPost, "/submit.php", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	gateway.Routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "alipaysubmit")
+	require.Contains(t, rec.Body.String(), "openapi.alipay.com/gateway.do")
+
+	order, ok, err := store.Find("USR1NOabc")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, OrderStatusPaying, order.Status)
+}
+
+func TestAlipayNotifyCallbacksNewAPIOnce(t *testing.T) {
+	cfg := validTestConfig(t)
+	var callbackCount int32
+	newAPIServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		require.True(t, VerifyEPayParams(firstFormValues(r.PostForm), cfg.EPayKey))
+		require.Equal(t, "USR1NOabc", r.PostForm.Get("out_trade_no"))
+		require.Equal(t, "TRADE_SUCCESS", r.PostForm.Get("trade_status"))
+		atomic.AddInt32(&callbackCount, 1)
+		_, _ = w.Write([]byte("success"))
+	}))
+	defer newAPIServer.Close()
+
+	store, err := NewFileOrderStore(cfg.OrderStorePath)
+	require.NoError(t, err)
+	_, _, err = store.UpsertFromSubmit(&Order{
+		OutTradeNo:  "USR1NOabc",
+		PID:         cfg.EPayPID,
+		PaymentType: "alipay",
+		Subject:     "TUC10",
+		Amount:      "7.30",
+		NotifyURL:   newAPIServer.URL,
+		ReturnURL:   "https://kittyvibe.ai/console/log",
+	})
+	require.NoError(t, err)
+
+	gateway := NewGateway(cfg, store, nil)
+	notify := signedAlipayNotify(t, cfg, nil)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/alipay/notify", strings.NewReader(notify.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+
+		gateway.Routes().ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "success", rec.Body.String())
+	}
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&callbackCount))
+	order, ok, err := store.Find("USR1NOabc")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, OrderStatusCallbackSuccess, order.Status)
+}
+
+func TestAlipayNotifyRejectsAmountMismatch(t *testing.T) {
+	cfg := validTestConfig(t)
+	store, err := NewFileOrderStore(cfg.OrderStorePath)
+	require.NoError(t, err)
+	_, _, err = store.UpsertFromSubmit(&Order{
+		OutTradeNo:  "USR1NOabc",
+		PID:         cfg.EPayPID,
+		PaymentType: "alipay",
+		Subject:     "TUC10",
+		Amount:      "7.30",
+		NotifyURL:   "https://kittyvibe.ai/api/user/epay/notify",
+		ReturnURL:   "https://kittyvibe.ai/console/log",
+	})
+	require.NoError(t, err)
+
+	gateway := NewGateway(cfg, store, nil)
+	notify := signedAlipayNotify(t, cfg, map[string]string{"total_amount": "7.31"})
+	req := httptest.NewRequest(http.MethodPost, "/alipay/notify", strings.NewReader(notify.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	gateway.Routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "fail", rec.Body.String())
+	order, ok, err := store.Find("USR1NOabc")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, OrderStatusCreated, order.Status)
+}

--- a/epay/test_helpers_test.go
+++ b/epay/test_helpers_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func validTestConfig(t *testing.T) Config {
+	privateKey, publicKey := testRSAKeys(t)
+	return Config{
+		ListenAddr:            ":0",
+		PublicBaseURL:         "https://pay.kittyvibe.ai",
+		EPayPID:               "kittyvibe",
+		EPayKey:               "epay-secret",
+		AllowedNotifyHosts:    map[string]struct{}{"kittyvibe.ai": {}},
+		AlipayAppID:           "2021000000000000",
+		AlipayAppPrivateKey:   privateKey,
+		AlipayPublicKey:       publicKey,
+		AlipaySellerID:        "2088000000000000",
+		AlipayGateway:         "https://openapi.alipay.com/gateway.do",
+		OrderStorePath:        t.TempDir() + "/orders.json",
+		HTTPTimeout:           defaultHTTPTimeout,
+		CallbackRetryInterval: defaultCallbackRetryInterval,
+	}
+}
+
+func testRSAKeys(t *testing.T) (string, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	privateDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	privatePEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateDER}))
+
+	publicDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	require.NoError(t, err)
+	publicPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicDER}))
+	return privatePEM, publicPEM
+}
+
+func signedEPayForm(cfg Config, overrides map[string]string) url.Values {
+	params := map[string]string{
+		"pid":          cfg.EPayPID,
+		"type":         "alipay",
+		"out_trade_no": "USR1NOabc",
+		"notify_url":   "https://kittyvibe.ai/api/user/epay/notify",
+		"return_url":   "https://kittyvibe.ai/console/log",
+		"name":         "TUC10",
+		"money":        "7.30",
+		"device":       "pc",
+	}
+	for k, v := range overrides {
+		params[k] = v
+	}
+	params = AddEPaySignature(params, cfg.EPayKey)
+	form := url.Values{}
+	for k, v := range params {
+		form.Set(k, v)
+	}
+	return form
+}
+
+func signedAlipayNotify(t *testing.T, cfg Config, overrides map[string]string) url.Values {
+	t.Helper()
+	params := map[string]string{
+		"app_id":       cfg.AlipayAppID,
+		"seller_id":    cfg.AlipaySellerID,
+		"out_trade_no": "USR1NOabc",
+		"trade_no":     "2026050722000000000001",
+		"trade_status": "TRADE_SUCCESS",
+		"total_amount": "7.30",
+		"subject":      "TUC10",
+		"sign_type":    "RSA2",
+		"charset":      "utf-8",
+		"gmt_payment":  "2026-05-07 10:00:00",
+		"notify_time":  "2026-05-07 10:00:01",
+		"notify_type":  "trade_status_sync",
+		"notify_id":    "notify-id",
+		"version":      "1.0",
+		"buyer_id":     "2088000000000001",
+	}
+	for k, v := range overrides {
+		params[k] = v
+	}
+	sign, err := signAlipayParams(params, cfg.AlipayAppPrivateKey)
+	require.NoError(t, err)
+	params["sign"] = sign
+
+	values := url.Values{}
+	for k, v := range params {
+		values.Set(k, v)
+	}
+	return values
+}

--- a/epay/test_helpers_test.go
+++ b/epay/test_helpers_test.go
@@ -23,6 +23,7 @@ func validTestConfig(t *testing.T) Config {
 		AlipayAppPrivateKey:   privateKey,
 		AlipayPublicKey:       publicKey,
 		AlipaySellerID:        "2088000000000000",
+		AlipaySandbox:         false,
 		AlipayGateway:         "https://openapi.alipay.com/gateway.do",
 		OrderStorePath:        t.TempDir() + "/orders.json",
 		HTTPTimeout:           defaultHTTPTimeout,


### PR DESCRIPTION
## Summary
- Add an isolated top-level epay gateway service for EPay-compatible Alipay page-pay proxying.
- Implement EPay MD5 request validation, Alipay RSA2 page-pay signing/notify verification, New API callback forwarding, and callback retry.
- Add file-backed and Neon/Postgres-backed order storage behind the same OrderStore interface, including epay_orders state and epay_order_events audit records.
- Harden the public payment endpoints with 64KB form-body limits, HTTP server read/write/idle timeouts, startup-time Alipay key parsing, and production seller_id validation.
- Add local deployment examples for Caddy, systemd, Docker Compose, plus an env template with placeholder-only secrets.

## Test Plan
- go test ./epay
- go vet ./epay
- git diff --check
- TEST_DATABASE_URL=<Neon pooled connection string> go test ./epay -run TestPostgresOrderStoreContract -count=1

## Security Notes
- Alipay private key stays in the standalone gateway, not the New API app.
- notify_url and return_url are restricted to allowed HTTPS hosts.
- ALIPAY_SELLER_ID is required in production and may only be empty for sandbox mode.
- Gateway request bodies are capped in code and in the Caddy example; production should also enable edge/WAF rate limiting for POST /submit.php and POST /alipay/notify.
- Neon/DATABASE_URL is read from environment only and is not committed.
- Temporary local test keys/cookies were removed before pushing.