### PR TITLE
fix(seedance): preserve video duration and resolution

### DIFF
--- a/relay/channel/task/doubao/adaptor.go
+++ b/relay/channel/task/doubao/adaptor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -122,7 +121,7 @@ func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
 //
 //   - first_frame + last_frame  → firstTailGenerate (首尾生视频)
 //   - any video_url             → referenceGenerate (参照生视频, covers
-//                                  multi-modal / edit / extend)
+//     multi-modal / edit / extend)
 //   - any image_url             → generate (图生视频)
 //   - text only                 → textGenerate (文生视频)
 //
@@ -428,8 +427,11 @@ func (a *TaskAdaptor) convertToRequestPayload(req *relaycommon.TaskSubmitReq) (*
 		return nil, errors.Wrap(err, "unmarshal metadata failed")
 	}
 
-	if sec, _ := strconv.Atoi(req.Seconds); sec > 0 {
-		r.Duration = lo.ToPtr(dto.IntValue(sec))
+	if resolution := firstString(req.Resolution, req.Size); resolution != "" {
+		r.Resolution = resolution
+	}
+	if duration := firstPositiveInt(req.Duration, atoi(req.Seconds)); duration > 0 {
+		r.Duration = lo.ToPtr(dto.IntValue(duration))
 	}
 
 	r.Content = lo.Reject(r.Content, func(c ContentItem, _ int) bool { return c.Type == "text" })

--- a/relay/channel/task/doubao/adaptor_test.go
+++ b/relay/channel/task/doubao/adaptor_test.go
@@ -1,0 +1,90 @@
+package doubao
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertToRequestPayloadUsesTopLevelDurationAndResolution(t *testing.T) {
+	raw := []byte(`{
+		"model": "doubao-seedance-2-0-260128",
+		"prompt": "切换到面部特写，角色露出邪魅一笑。",
+		"metadata": {
+			"content": [
+				{
+					"type": "image_url",
+					"image_url": {
+						"url": "https://example.com/first-frame.png"
+					},
+					"role": "first_frame"
+				}
+			],
+			"audit_image": true
+		},
+		"duration": 4,
+		"resolution": "480p"
+	}`)
+
+	var req relaycommon.TaskSubmitReq
+	require.NoError(t, common.Unmarshal(raw, &req))
+
+	got, err := (&TaskAdaptor{}).convertToRequestPayload(&req)
+	require.NoError(t, err)
+
+	require.Equal(t, "doubao-seedance-2-0-260128", got.Model)
+	require.Equal(t, "480p", got.Resolution)
+	require.NotNil(t, got.Duration)
+	require.Equal(t, 4, int(*got.Duration))
+
+	require.Len(t, got.Content, 2)
+	require.Equal(t, "image_url", got.Content[0].Type)
+	require.Equal(t, "first_frame", got.Content[0].Role)
+	require.NotNil(t, got.Content[0].ImageURL)
+	require.Equal(t, "https://example.com/first-frame.png", got.Content[0].ImageURL.URL)
+	require.Equal(t, "text", got.Content[1].Type)
+	require.Equal(t, "切换到面部特写，角色露出邪魅一笑。", got.Content[1].Text)
+}
+
+func TestConvertToRequestPayloadDurationSources(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			name: "top level duration number",
+			body: `{"model":"doubao-seedance-2-0-260128","prompt":"test","duration":4}`,
+			want: 4,
+		},
+		{
+			name: "top level duration string",
+			body: `{"model":"doubao-seedance-2-0-260128","prompt":"test","duration":"6"}`,
+			want: 6,
+		},
+		{
+			name: "legacy seconds string",
+			body: `{"model":"doubao-seedance-2-0-260128","prompt":"test","seconds":"8"}`,
+			want: 8,
+		},
+		{
+			name: "duration wins over seconds",
+			body: `{"model":"doubao-seedance-2-0-260128","prompt":"test","duration":4,"seconds":"8"}`,
+			want: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req relaycommon.TaskSubmitReq
+			require.NoError(t, common.Unmarshal([]byte(tt.body), &req))
+
+			got, err := (&TaskAdaptor{}).convertToRequestPayload(&req)
+			require.NoError(t, err)
+			require.NotNil(t, got.Duration)
+			require.Equal(t, tt.want, int(*got.Duration))
+		})
+	}
+}

--- a/relay/channel/task/doubao/billing.go
+++ b/relay/channel/task/doubao/billing.go
@@ -13,7 +13,7 @@ import (
 
 func ExtractRequestBillingInput(req relaycommon.TaskSubmitReq, profile videobilling.VideoBillingProfile, groupRatio float64) service.VideoBillingInput {
 	outputSeconds := firstPositiveInt(req.Duration, atoi(req.Seconds), intFromMap(req.Metadata, "duration"), intFromMap(req.Metadata, "seconds"))
-	width, height := resolveVideoDimensions(profile, firstString(req.Size, stringFromMap(req.Metadata, "size"), stringFromMap(req.Metadata, "resolution")))
+	width, height := resolveVideoDimensions(profile, firstString(req.Resolution, req.Size, stringFromMap(req.Metadata, "size"), stringFromMap(req.Metadata, "resolution")))
 	fps := firstPositiveInt(intFromMap(req.Metadata, "fps"), intFromMap(req.Metadata, "framespersecond"), profile.FallbackFPS)
 	draft := boolFromMap(req.Metadata, "draft")
 

--- a/relay/channel/task/doubao/billing_test.go
+++ b/relay/channel/task/doubao/billing_test.go
@@ -25,6 +25,7 @@ func testProfile() videobilling.VideoBillingProfile {
 		ReferenceConservativeMultiplier: 2,
 		DraftMultiplier:                 0.5,
 		ResolutionAliases: map[string]videobilling.VideoResolution{
+			"480p":     {Width: 832, Height: 480},
 			"720p":     {Width: 1280, Height: 720},
 			"1080p":    {Width: 1920, Height: 1080},
 			"1280x720": {Width: 1280, Height: 720},
@@ -87,6 +88,25 @@ func TestExtractRequestBillingInput(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestExtractRequestBillingInputUsesTopLevelResolution(t *testing.T) {
+	var req relaycommon.TaskSubmitReq
+	require.NoError(t, common.Unmarshal([]byte(`{
+		"model": "doubao-seedance-2-0-260128",
+		"prompt": "切换到面部特写，角色露出邪魅一笑。",
+		"duration": 4,
+		"resolution": "480p"
+	}`), &req))
+
+	got := ExtractRequestBillingInput(req, testProfile(), 1)
+	require.Equal(t, service.VideoBillingInput{
+		OutputSeconds: 4,
+		Width:         832,
+		Height:        480,
+		FPS:           24,
+		GroupRatio:    1,
+	}, got)
 }
 
 func TestExtractRequestBillingInputMarksReferenceMedia(t *testing.T) {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -681,6 +681,7 @@ type TaskSubmitReq struct {
 	Images         []string                 `json:"images,omitempty"`
 	Content        []map[string]interface{} `json:"content,omitempty"`
 	Size           string                   `json:"size,omitempty"`
+	Resolution     string                   `json:"resolution,omitempty"`
 	Duration       int                      `json:"duration,omitempty"`
 	Seconds        string                   `json:"seconds,omitempty"`
 	InputReference string                   `json:"input_reference,omitempty"`

--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -86,12 +86,13 @@ func validateMultipartTaskRequest(c *gin.Context, info *RelayInfo, action string
 
 	formData := c.Request.PostForm
 	req = TaskSubmitReq{
-		Prompt:   formData.Get("prompt"),
-		Model:    formData.Get("model"),
-		Mode:     formData.Get("mode"),
-		Image:    formData.Get("image"),
-		Size:     formData.Get("size"),
-		Metadata: make(map[string]interface{}),
+		Prompt:     formData.Get("prompt"),
+		Model:      formData.Get("model"),
+		Mode:       formData.Get("mode"),
+		Image:      formData.Get("image"),
+		Size:       formData.Get("size"),
+		Resolution: formData.Get("resolution"),
+		Metadata:   make(map[string]interface{}),
 	}
 
 	if durationStr := formData.Get("seconds"); durationStr != "" {
@@ -189,6 +190,7 @@ func isKnownTaskField(field string) bool {
 		"image":           true,
 		"images":          true,
 		"size":            true,
+		"resolution":      true,
 		"duration":        true,
 		"input_reference": true, // Sora 特有字段
 	}


### PR DESCRIPTION
## Summary
- Preserve top-level `duration` and `resolution` for Doubao/Seedance task submits so existing client calls keep working.
- Add `resolution` to the unified task request shape and multipart known fields.
- Keep precharge billing aligned with the submitted top-level resolution.

## Root Cause
Seedance requests could pass `duration` and `resolution` at the top level, but `resolution` was not parsed into `TaskSubmitReq`, and the Doubao adaptor only forwarded `seconds` to upstream. Upstream then defaulted to 720p / 5s.

## Test Plan
- `go test ./relay/channel/task/doubao`
- `go test ./relay/common`
- `go test ./relay/...`
- `go test ./...`