### PR TITLE
fix(doubao): honour top-level duration and resolution

### DIFF
--- a/relay/channel/task/doubao/adaptor.go
+++ b/relay/channel/task/doubao/adaptor.go
@@ -428,8 +428,19 @@ func (a *TaskAdaptor) convertToRequestPayload(req *relaycommon.TaskSubmitReq) (*
 		return nil, errors.Wrap(err, "unmarshal metadata failed")
 	}
 
-	if sec, _ := strconv.Atoi(req.Seconds); sec > 0 {
-		r.Duration = lo.ToPtr(dto.IntValue(sec))
+	// Honour top-level passthrough fields when metadata didn't already set them.
+	// OpenAI Videos clients put `resolution` and numeric `duration` at the root
+	// of the request body; without this fallback the upstream Volcano Ark API
+	// receives nothing and silently substitutes its defaults (720p, 5s).
+	if r.Resolution == "" && req.Resolution != "" {
+		r.Resolution = req.Resolution
+	}
+	if r.Duration == nil {
+		if req.Duration > 0 {
+			r.Duration = lo.ToPtr(dto.IntValue(req.Duration))
+		} else if sec, _ := strconv.Atoi(req.Seconds); sec > 0 {
+			r.Duration = lo.ToPtr(dto.IntValue(sec))
+		}
 	}
 
 	r.Content = lo.Reject(r.Content, func(c ContentItem, _ int) bool { return c.Type == "text" })

--- a/relay/channel/task/doubao/adaptor_test.go
+++ b/relay/channel/task/doubao/adaptor_test.go
@@ -1,0 +1,70 @@
+package doubao
+
+import (
+	"testing"
+
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+// Top-level `duration` (int) and `resolution` (string) on the OpenAI Videos
+// request shape must reach the upstream Volcano Ark payload — otherwise the
+// upstream silently falls back to 5s/720p and bills accordingly.
+func TestConvertToRequestPayloadHonoursTopLevelDurationAndResolution(t *testing.T) {
+	a := &TaskAdaptor{}
+
+	t.Run("top-level duration and resolution flow through", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:      "doubao-seedance-2-0-260128",
+			Prompt:     "切换到面部特写",
+			Duration:   4,
+			Resolution: "480p",
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.NotNil(t, body.Duration, "top-level duration must populate payload")
+		require.Equal(t, 4, int(*body.Duration))
+		require.Equal(t, "480p", body.Resolution)
+	})
+
+	t.Run("metadata still overrides top-level", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:      "doubao-seedance-2-0-260128",
+			Prompt:     "p",
+			Duration:   4,
+			Resolution: "480p",
+			Metadata: map[string]any{
+				"duration":   8,
+				"resolution": "1080p",
+			},
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.NotNil(t, body.Duration)
+		require.Equal(t, 8, int(*body.Duration))
+		require.Equal(t, "1080p", body.Resolution)
+	})
+
+	t.Run("seconds string still works as fallback", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:   "doubao-seedance-2-0-260128",
+			Prompt:  "p",
+			Seconds: "6",
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.NotNil(t, body.Duration)
+		require.Equal(t, 6, int(*body.Duration))
+	})
+
+	t.Run("nothing set leaves duration nil", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:  "doubao-seedance-2-0-260128",
+			Prompt: "p",
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.Nil(t, body.Duration)
+		require.Equal(t, "", body.Resolution)
+	})
+}

--- a/relay/channel/task/doubao/billing.go
+++ b/relay/channel/task/doubao/billing.go
@@ -13,7 +13,7 @@ import (
 
 func ExtractRequestBillingInput(req relaycommon.TaskSubmitReq, profile videobilling.VideoBillingProfile, groupRatio float64) service.VideoBillingInput {
 	outputSeconds := firstPositiveInt(req.Duration, atoi(req.Seconds), intFromMap(req.Metadata, "duration"), intFromMap(req.Metadata, "seconds"))
-	width, height := resolveVideoDimensions(profile, firstString(req.Size, stringFromMap(req.Metadata, "size"), stringFromMap(req.Metadata, "resolution")))
+	width, height := resolveVideoDimensions(profile, firstString(req.Resolution, req.Size, stringFromMap(req.Metadata, "size"), stringFromMap(req.Metadata, "resolution")))
 	fps := firstPositiveInt(intFromMap(req.Metadata, "fps"), intFromMap(req.Metadata, "framespersecond"), profile.FallbackFPS)
 	draft := boolFromMap(req.Metadata, "draft")
 

--- a/relay/channel/task/doubao/billing_test.go
+++ b/relay/channel/task/doubao/billing_test.go
@@ -25,6 +25,7 @@ func testProfile() videobilling.VideoBillingProfile {
 		ReferenceConservativeMultiplier: 2,
 		DraftMultiplier:                 0.5,
 		ResolutionAliases: map[string]videobilling.VideoResolution{
+			"480p":     {Width: 832, Height: 480},
 			"720p":     {Width: 1280, Height: 720},
 			"1080p":    {Width: 1920, Height: 1080},
 			"1280x720": {Width: 1280, Height: 720},
@@ -87,6 +88,28 @@ func TestExtractRequestBillingInput(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// Top-level `resolution` on the OpenAI Videos shape must drive the precharge
+// billing estimate; otherwise we fall back to profile defaults and quote the
+// user against 720p instead of the 480p they asked for.
+func TestExtractRequestBillingInputUsesTopLevelResolution(t *testing.T) {
+	var req relaycommon.TaskSubmitReq
+	require.NoError(t, common.Unmarshal([]byte(`{
+		"model": "doubao-seedance-2-0-260128",
+		"prompt": "切换到面部特写，角色露出邪魅一笑。",
+		"duration": 4,
+		"resolution": "480p"
+	}`), &req))
+
+	got := ExtractRequestBillingInput(req, testProfile(), 1)
+	require.Equal(t, service.VideoBillingInput{
+		OutputSeconds: 4,
+		Width:         832,
+		Height:        480,
+		FPS:           24,
+		GroupRatio:    1,
+	}, got)
 }
 
 func TestExtractRequestBillingInputMarksReferenceMedia(t *testing.T) {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -681,6 +681,7 @@ type TaskSubmitReq struct {
 	Images         []string                 `json:"images,omitempty"`
 	Content        []map[string]interface{} `json:"content,omitempty"`
 	Size           string                   `json:"size,omitempty"`
+	Resolution     string                   `json:"resolution,omitempty"`
 	Duration       int                      `json:"duration,omitempty"`
 	Seconds        string                   `json:"seconds,omitempty"`
 	InputReference string                   `json:"input_reference,omitempty"`

--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -86,12 +86,13 @@ func validateMultipartTaskRequest(c *gin.Context, info *RelayInfo, action string
 
 	formData := c.Request.PostForm
 	req = TaskSubmitReq{
-		Prompt:   formData.Get("prompt"),
-		Model:    formData.Get("model"),
-		Mode:     formData.Get("mode"),
-		Image:    formData.Get("image"),
-		Size:     formData.Get("size"),
-		Metadata: make(map[string]interface{}),
+		Prompt:     formData.Get("prompt"),
+		Model:      formData.Get("model"),
+		Mode:       formData.Get("mode"),
+		Image:      formData.Get("image"),
+		Size:       formData.Get("size"),
+		Resolution: formData.Get("resolution"),
+		Metadata:   make(map[string]interface{}),
 	}
 
 	if durationStr := formData.Get("seconds"); durationStr != "" {
@@ -189,6 +190,7 @@ func isKnownTaskField(field string) bool {
 		"image":           true,
 		"images":          true,
 		"size":            true,
+		"resolution":      true,
 		"duration":        true,
 		"input_reference": true, // Sora 特有字段
 	}


### PR DESCRIPTION
## Summary

- `TaskSubmitReq` now has a `Resolution` field, so top-level `resolution` on OpenAI-Videos-shaped requests survives parsing instead of being silently dropped.
- `relay/channel/task/doubao/adaptor.go::convertToRequestPayload` falls back to `req.Duration` / `req.Resolution` when `metadata` didn't already set them; metadata still wins on conflict.
- New unit test in `adaptor_test.go` covers top-level passthrough, metadata override precedence, the `seconds` string fallback, and the all-empty case.

Fixes #45.

## Why

When a caller submits a Seedance task to `POST /v1/videos` (or `/v1/video/generations`) with:

```json
{ "model": "doubao-seedance-2-0-260128", "prompt": "...", "metadata": {...}, "duration": 4, "resolution": "480p" }
```

the adaptor was only reading `req.Seconds` (string) and `req.Metadata["resolution"]`. The numeric top-level `duration` landed in `req.Duration` but was never consulted, and `resolution` had no field to land in at all. Volcano Ark received neither field, fell back to 720p × 5s, and the user was billed for the upgraded output (54 450 quota in the issue's repro). Every other task adaptor (hailuo, gemini, vertex, ali, pixverse, vidu, kling, sora) already honours `req.Duration` — doubao was the lone exception.

The Volcano-shaped path `POST /api/v3/contents/generations/tasks` is unaffected because `VolcArkSubmitConvert` already copies the entire raw body into `metadata`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./relay/channel/task/doubao/... ./relay/common/...`
- [x] New `TestConvertToRequestPayloadHonoursTopLevelDurationAndResolution` covers the bug + regression cases
- [ ] Smoke test against running container with the original repro payload (verify upstream URL on TOS shows requested `duration=4` / `resolution=480p`)



#44 

🤖 Generated with [Claude Code](https://claude.com/claude-code)