### PR TITLE
[codex] fix doubao billing precedence

### DIFF
--- a/relay/channel/task/doubao/billing.go
+++ b/relay/channel/task/doubao/billing.go
@@ -12,8 +12,8 @@ import (
 )
 
 func ExtractRequestBillingInput(req relaycommon.TaskSubmitReq, profile videobilling.VideoBillingProfile, groupRatio float64) service.VideoBillingInput {
-	outputSeconds := firstPositiveInt(req.Duration, atoi(req.Seconds), intFromMap(req.Metadata, "duration"), intFromMap(req.Metadata, "seconds"))
-	width, height := resolveVideoDimensions(profile, firstString(req.Resolution, req.Size, stringFromMap(req.Metadata, "size"), stringFromMap(req.Metadata, "resolution")))
+	outputSeconds := firstPositiveInt(intFromMap(req.Metadata, "duration"), req.Duration, atoi(req.Seconds), intFromMap(req.Metadata, "seconds"))
+	width, height := resolveVideoDimensions(profile, firstString(stringFromMap(req.Metadata, "resolution"), req.Resolution, req.Size, stringFromMap(req.Metadata, "size")))
 	fps := firstPositiveInt(intFromMap(req.Metadata, "fps"), intFromMap(req.Metadata, "framespersecond"), profile.FallbackFPS)
 	draft := boolFromMap(req.Metadata, "draft")
 

--- a/relay/channel/task/doubao/billing_test.go
+++ b/relay/channel/task/doubao/billing_test.go
@@ -112,6 +112,25 @@ func TestExtractRequestBillingInputUsesTopLevelResolution(t *testing.T) {
 	}, got)
 }
 
+func TestExtractRequestBillingInputMetadataOverridesTopLevel(t *testing.T) {
+	got := ExtractRequestBillingInput(relaycommon.TaskSubmitReq{
+		Duration:   4,
+		Resolution: "480p",
+		Metadata: map[string]any{
+			"duration":   8,
+			"resolution": "1080p",
+		},
+	}, testProfile(), 1)
+
+	require.Equal(t, service.VideoBillingInput{
+		OutputSeconds: 8,
+		Width:         1920,
+		Height:        1080,
+		FPS:           24,
+		GroupRatio:    1,
+	}, got)
+}
+
 func TestExtractRequestBillingInputMarksReferenceMedia(t *testing.T) {
 	got := ExtractRequestBillingInput(relaycommon.TaskSubmitReq{
 		Duration: 5,


### PR DESCRIPTION
## Summary
- Align Doubao video precharge billing precedence with the upstream request adapter.
- Keep metadata duration/resolution overriding top-level values, matching `convertToRequestPayload`.
- Add a regression test for conflicting top-level and metadata values.

## Root Cause
PR #47 made top-level `duration` and `resolution` flow through to Doubao, but billing selected those top-level fields before metadata. The adapter applies metadata first and only falls back to top-level fields, so conflict requests could precharge one set of video params and submit another upstream.

## Validation
- `go test ./relay/channel/task/doubao ./relay/common ./relay`