### PR TITLE
fix(wallet): show topup currency on amount cards + credit-add delta in usage logs

### DIFF
--- a/web/default/src/features/usage-logs/components/columns/common-logs-columns.tsx
+++ b/web/default/src/features/usage-logs/components/columns/common-logs-columns.tsx
@@ -673,9 +673,22 @@ export function useCommonLogsColumns(isAdmin: boolean): ColumnDef<UsageLog>[] {
       ),
       cell: ({ row }) => {
         const log = row.original
+        const quota = row.getValue('quota') as number
+
+        // Show credit additions (topup / manage / refund) so the user can see
+        // their balance change in this column too, not just in the details text.
+        const isCreditAdd =
+          log.type === 1 || log.type === 3 || log.type === 6
+        if (isCreditAdd && quota > 0) {
+          return (
+            <span className='inline-flex w-fit items-center rounded-md border border-emerald-200/60 bg-emerald-50 px-1.5 py-0.5 font-mono text-xs font-semibold tabular-nums text-emerald-700 dark:border-emerald-800/60 dark:bg-emerald-950/40 dark:text-emerald-300'>
+              +{formatLogQuota(quota)}
+            </span>
+          )
+        }
+
         if (!isDisplayableLogType(log.type)) return null
 
-        const quota = row.getValue('quota') as number
         const other = parseLogOther(log.other)
         const isSubscription = other?.billing_source === 'subscription'
 

--- a/web/default/src/features/wallet/components/recharge-form-card.tsx
+++ b/web/default/src/features/wallet/components/recharge-form-card.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Gift, ExternalLink, Loader2, Receipt, WalletCards } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { formatNumber } from '@/lib/format'
+import { formatCurrencyFromUSD } from '@/lib/currency'
 import { cn } from '@/lib/utils'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -50,7 +50,6 @@ interface RechargeFormCardProps {
   topupLink?: string
   loading?: boolean
   priceRatio?: number
-  usdExchangeRate?: number
   onOpenBilling?: () => void
   creemProducts?: CreemProduct[]
   enableCreemTopup?: boolean
@@ -80,7 +79,6 @@ export function RechargeFormCard({
   topupLink,
   loading,
   priceRatio = 1,
-  usdExchangeRate = 1,
   onOpenBilling,
   creemProducts,
   enableCreemTopup,
@@ -203,17 +201,12 @@ export function RechargeFormCard({
                         preset.discount ||
                         topupInfo?.discount?.[preset.value] ||
                         1.0
-                      const {
-                        displayValue,
-                        actualPrice,
-                        savedAmount,
-                        hasDiscount,
-                      } = calculatePresetPricing(
-                        preset.value,
-                        priceRatio,
-                        discount,
-                        usdExchangeRate
-                      )
+                      const { actualPrice, savedAmount, hasDiscount } =
+                        calculatePresetPricing(
+                          preset.value,
+                          priceRatio,
+                          discount
+                        )
                       return (
                         <Button
                           key={index}
@@ -228,7 +221,12 @@ export function RechargeFormCard({
                         >
                           <div className='flex w-full items-center justify-between'>
                             <div className='text-base font-semibold sm:text-lg'>
-                              {formatNumber(displayValue)}
+                              {formatCurrencyFromUSD(preset.value, {
+                                digitsLarge: 2,
+                                digitsSmall: 2,
+                                abbreviate: false,
+                                useCreditDisplay: false,
+                              })}
                             </div>
                             {hasDiscount && (
                               <div className='text-xs font-medium text-green-600'>
@@ -266,7 +264,15 @@ export function RechargeFormCard({
                     value={localAmount}
                     onChange={(e) => handleAmountChange(e.target.value)}
                     min={minTopup}
-                    placeholder={`Minimum ${minTopup}`}
+                    placeholder={`${t('Minimum')} ${formatCurrencyFromUSD(
+                      minTopup,
+                      {
+                        digitsLarge: 2,
+                        digitsSmall: 2,
+                        abbreviate: false,
+                        useCreditDisplay: false,
+                      }
+                    )}`}
                     className='h-9 text-base sm:h-10 sm:text-lg'
                   />
                   <div className='bg-muted/30 flex min-h-9 items-center justify-between gap-2 rounded-md border px-3 lg:min-w-52'>

--- a/web/default/src/features/wallet/index.tsx
+++ b/web/default/src/features/wallet/index.tsx
@@ -276,7 +276,6 @@ export function Wallet(props: WalletProps) {
                   topupLink={topupInfo?.topup_link}
                   loading={topupLoading}
                   priceRatio={(status?.usd_exchange_rate as number) || 1}
-                  usdExchangeRate={effectiveUsdExchangeRate}
                   onOpenBilling={() => setBillingDialogOpen(true)}
                   creemProducts={topupInfo?.creem_products}
                   enableCreemTopup={topupInfo?.enable_creem_topup}

--- a/web/default/src/features/wallet/lib/format.ts
+++ b/web/default/src/features/wallet/lib/format.ts
@@ -64,17 +64,14 @@ export function getDiscountLabel(discount: number): string {
 export function calculatePresetPricing(
   presetValue: number,
   priceRatio: number,
-  discount: number,
-  usdExchangeRate: number = 1
+  discount: number
 ) {
   const originalPrice = presetValue * priceRatio
   const actualPrice = originalPrice * discount
   const savedAmount = originalPrice - actualPrice
   const hasDiscount = discount < 1.0
-  const displayValue = presetValue * usdExchangeRate
 
   return {
-    displayValue,
     originalPrice,
     actualPrice,
     savedAmount,

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -2317,6 +2317,7 @@
     "Min Top-up": "最低充值",
     "Min Top-up:": "最低充值：",
     "MiniMax": "MiniMax",
+    "Minimum": "最低",
     "Minimum check-in quota": "签到最小额度",
     "Minimum LinuxDO trust level required": "所需的最低 LinuxDO 信任级别",
     "Minimum quota amount awarded for check-in": "签到奖励的最小额度",


### PR DESCRIPTION
## Summary
Follow-up to #53 (already merged) — two more visibility fixes the user surfaced:

1. **Recharge preset cards didn't show the topup currency.** They rendered just \`10\` with \`Pay ¥70\` underneath, leaving "is that 10 USD or 10 of some other unit?" ambiguous. Now goes through \`formatCurrencyFromUSD\` so it adapts to the user's display mode: \`\$10\` (USD), \`¥70\` (CNY), \`5,000,000\` (tokens), \`€9\` (custom).
2. **Usage Logs "Cost" column was empty for topup / manage / refund rows.** \`DISPLAYABLE_LOG_TYPES\` excluded type 1 (topup) and 3 (manage), so the only place a user could see "I just got \$1 of credit" was in the buried details text. Now those rows show a green chip \`+\$1.00\` so balance changes are visible at a glance alongside consume rows.

## What changed
- \`recharge-form-card.tsx\`: preset card amount uses \`formatCurrencyFromUSD\`. Custom amount placeholder includes the currency symbol too. Drops now-unused \`displayValue\`/\`usdExchangeRate\` from \`calculatePresetPricing\` and the \`RechargeFormCard\` props.
- \`common-logs-columns.tsx\` (Cost cell): renders a green \`+\$X\` chip for type 1/3/6 with positive quota, before falling through to the existing displayable-types path.
- zh.json: new \"Minimum\" → \"最低\".

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bun test src/lib/currency.test.ts\` — 7/7 still pass
- [ ] Visual check on staging: \`/wallet\` preset cards show currency; \`/usage-logs\` topup row shows green \`+\$1.00\` in 费用 column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)