### PR TITLE
fix(log): persist credit amount on topup log rows

### DIFF
--- a/controller/topup.go
+++ b/controller/topup.go
@@ -395,7 +395,7 @@ func EpayNotify(c *gin.Context) {
 				return
 			}
 			logger.LogInfo(c.Request.Context(), fmt.Sprintf("易支付 充值成功 trade_no=%s user_id=%d client_ip=%s quota_to_add=%d money=%.2f topup=%q", topUp.TradeNo, topUp.UserId, c.ClientIP(), quotaToAdd, topUp.Money, common.GetJsonString(topUp)))
-			model.RecordTopupLog(topUp.UserId, fmt.Sprintf("使用在线充值成功，充值金额: %v，支付金额：%f", logger.LogQuota(quotaToAdd), topUp.Money), c.ClientIP(), topUp.PaymentMethod, "epay")
+			model.RecordTopupLog(topUp.UserId, quotaToAdd, fmt.Sprintf("使用在线充值成功，充值金额: %v，支付金额：%f", logger.LogQuota(quotaToAdd), topUp.Money), c.ClientIP(), topUp.PaymentMethod, "epay")
 		}
 	} else {
 		logger.LogInfo(c.Request.Context(), fmt.Sprintf("易支付 webhook 忽略事件 trade_no=%s callback_type=%s trade_status=%s client_ip=%s verify_info=%q", verifyInfo.ServiceTradeNo, verifyInfo.Type, verifyInfo.TradeStatus, c.ClientIP(), common.GetJsonString(verifyInfo)))

--- a/model/log.go
+++ b/model/log.go
@@ -133,7 +133,7 @@ func RecordLogWithAdminInfo(userId int, logType int, content string, adminInfo m
 	}
 }
 
-func RecordTopupLog(userId int, content string, callerIp string, paymentMethod string, callbackPaymentMethod string) {
+func RecordTopupLog(userId int, quotaAdded int, content string, callerIp string, paymentMethod string, callbackPaymentMethod string) {
 	username, _ := GetUsernameById(userId, false)
 	adminInfo := map[string]interface{}{
 		"server_ip":               common.GetIp(),
@@ -152,6 +152,7 @@ func RecordTopupLog(userId int, content string, callerIp string, paymentMethod s
 		CreatedAt: common.GetTimestamp(),
 		Type:      LogTypeTopup,
 		Content:   content,
+		Quota:     quotaAdded,
 		Ip:        callerIp,
 		Other:     common.MapToJsonStr(other),
 	}

--- a/model/log_test.go
+++ b/model/log_test.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecordTopupLogPersistsQuota guards the regression behind PR #55:
+// RecordTopupLog used to write the topup amount only into Content and leave
+// Log.Quota = 0, which made the frontend Cost cell render blank for topup
+// rows in /usage-logs.
+//
+// If a future change drops the Quota field from the inserted row again, the
+// frontend `+$X` chip will silently disappear without a compile error — this
+// test is the canary.
+func TestRecordTopupLogPersistsQuota(t *testing.T) {
+	truncateTables(t)
+
+	const userID = 9001
+	const quotaAdded = 500_000 // tokens corresponding to $1 at QuotaPerUnit=500k
+
+	require.NoError(t, DB.Create(&User{
+		Id:       userID,
+		Username: "topup-test-user",
+	}).Error)
+
+	RecordTopupLog(
+		userID,
+		quotaAdded,
+		"使用在线充值成功，充值金额: $1.00，支付金额：7.30",
+		"127.0.0.1",
+		"alipay",
+		"epay",
+	)
+
+	var log Log
+	require.NoError(t, DB.Where("user_id = ? AND type = ?", userID, LogTypeTopup).First(&log).Error)
+
+	assert.Equal(t, quotaAdded, log.Quota,
+		"topup log must persist the credited quota — frontend Cost cell renders the green +$X chip from this field")
+	assert.Equal(t, LogTypeTopup, log.Type)
+	assert.Equal(t, userID, log.UserId)
+	assert.NotEmpty(t, log.Content, "content should still carry the human-readable summary")
+}

--- a/model/topup.go
+++ b/model/topup.go
@@ -152,7 +152,7 @@ func Recharge(referenceId string, customerId string, callerIp string) (err error
 		return errors.New("充值失败，请稍后重试")
 	}
 
-	RecordTopupLog(topUp.UserId, fmt.Sprintf("使用在线充值成功，充值金额: %v，支付金额：%d", logger.FormatQuota(int(quota)), topUp.Amount), callerIp, topUp.PaymentMethod, PaymentMethodStripe)
+	RecordTopupLog(topUp.UserId, int(quota), fmt.Sprintf("使用在线充值成功，充值金额: %v，支付金额：%d", logger.FormatQuota(int(quota)), topUp.Amount), callerIp, topUp.PaymentMethod, PaymentMethodStripe)
 
 	return nil
 }
@@ -384,7 +384,7 @@ func ManualCompleteTopUp(tradeNo string, callerIp string) error {
 	}
 
 	// 事务外记录日志，避免阻塞
-	RecordTopupLog(userId, fmt.Sprintf("管理员补单成功，充值金额: %v，支付金额：%f", logger.FormatQuota(quotaToAdd), payMoney), callerIp, paymentMethod, "admin")
+	RecordTopupLog(userId, quotaToAdd, fmt.Sprintf("管理员补单成功，充值金额: %v，支付金额：%f", logger.FormatQuota(quotaToAdd), payMoney), callerIp, paymentMethod, "admin")
 	return nil
 }
 func RechargeCreem(referenceId string, customerEmail string, customerName string, callerIp string) (err error) {
@@ -457,7 +457,7 @@ func RechargeCreem(referenceId string, customerEmail string, customerName string
 		return errors.New("充值失败，请稍后重试")
 	}
 
-	RecordTopupLog(topUp.UserId, fmt.Sprintf("使用Creem充值成功，充值额度: %v，支付金额：%.2f", quota, topUp.Money), callerIp, topUp.PaymentMethod, PaymentMethodCreem)
+	RecordTopupLog(topUp.UserId, int(quota), fmt.Sprintf("使用Creem充值成功，充值额度: %v，支付金额：%.2f", quota, topUp.Money), callerIp, topUp.PaymentMethod, PaymentMethodCreem)
 
 	return nil
 }
@@ -519,7 +519,7 @@ func RechargeWaffo(tradeNo string, callerIp string) (err error) {
 	}
 
 	if quotaToAdd > 0 {
-		RecordTopupLog(topUp.UserId, fmt.Sprintf("Waffo充值成功，充值额度: %v，支付金额: %.2f", logger.FormatQuota(quotaToAdd), topUp.Money), callerIp, topUp.PaymentMethod, PaymentMethodWaffo)
+		RecordTopupLog(topUp.UserId, quotaToAdd, fmt.Sprintf("Waffo充值成功，充值额度: %v，支付金额: %.2f", logger.FormatQuota(quotaToAdd), topUp.Money), callerIp, topUp.PaymentMethod, PaymentMethodWaffo)
 	}
 
 	return nil


### PR DESCRIPTION
## Why
Continuing the credit-history thread: after #54 added a green \`+\$X\` chip in the usage-logs Cost column for credit-add rows (type 1/3/6), topup rows still showed blank. Refund rows rendered fine, which made it more confusing.

Root cause is server-side: \`RecordTopupLog\` (model/log.go) puts the amount only in the \`Content\` string and leaves \`Log.Quota = 0\`. The frontend cell guards on \`quota > 0\`, so it correctly skipped rendering. Refund rows work because the refund pipeline writes \`Quota\` directly.

## Fix
- Add \`quotaAdded int\` parameter to \`RecordTopupLog\` and persist it to \`Log.Quota\`.
- Update all 5 callers to pass the credited amount: Epay (\`controller/topup.go\`), Stripe / admin manual top-up / Creem / Waffo (all in \`model/topup.go\`).

## Notes
- Pre-fix topup rows in the DB still have \`Quota = 0\`. The first row in this screenshot ([May 10 17:26 row](https://github.com/NekoAIKan/aikanhub/issues/...)) won't retroactively render. Only topups created after deploy will show the chip.
- No DB migration needed — \`Quota\` already exists; we're just stopping the silent write of 0.

## Test plan
- [x] \`go build ./controller/... ./model/... ./setting/... ./logger/...\` clean
- [ ] After deploy: trigger a small Epay test top-up → confirm the new row's 费用 column shows green \`+\$X\`
- [ ] (Optional) admin can manually backfill old topup rows by setting \`logs.quota\` from the value embedded in \`content\`, but probably not worth it

🤖 Generated with [Claude Code](https://claude.com/claude-code)