### PR TITLE
fix(payment): redirect post-payment users to current frontend routes

### DIFF
--- a/controller/subscription_payment_epay.go
+++ b/controller/subscription_payment_epay.go
@@ -173,7 +173,7 @@ func SubscriptionEpayReturn(c *gin.Context) {
 	if c.Request.Method == "POST" {
 		// POST 请求：从 POST body 解析参数
 		if err := c.Request.ParseForm(); err != nil {
-			c.Redirect(http.StatusFound, system_setting.ServerAddress+"/console/topup?pay=fail")
+			c.Redirect(http.StatusFound, system_setting.ServerAddress+"/wallet?pay=fail")
 			return
 		}
 		params = lo.Reduce(lo.Keys(c.Request.PostForm), func(r map[string]string, t string, i int) map[string]string {
@@ -189,29 +189,29 @@ func SubscriptionEpayReturn(c *gin.Context) {
 	}
 
 	if len(params) == 0 {
-		c.Redirect(http.StatusFound, system_setting.ServerAddress+"/console/topup?pay=fail")
+		c.Redirect(http.StatusFound, system_setting.ServerAddress+"/wallet?pay=fail")
 		return
 	}
 
 	client := GetEpayClient()
 	if client == nil {
-		c.Redirect(http.StatusFound, system_setting.ServerAddress+"/console/topup?pay=fail")
+		c.Redirect(http.StatusFound, system_setting.ServerAddress+"/wallet?pay=fail")
 		return
 	}
 	verifyInfo, err := client.Verify(params)
 	if err != nil || !verifyInfo.VerifyStatus {
-		c.Redirect(http.StatusFound, system_setting.ServerAddress+"/console/topup?pay=fail")
+		c.Redirect(http.StatusFound, system_setting.ServerAddress+"/wallet?pay=fail")
 		return
 	}
 	if verifyInfo.TradeStatus == epay.StatusTradeSuccess {
 		LockOrder(verifyInfo.ServiceTradeNo)
 		defer UnlockOrder(verifyInfo.ServiceTradeNo)
 		if err := model.CompleteSubscriptionOrder(verifyInfo.ServiceTradeNo, common.GetJsonString(verifyInfo), model.PaymentProviderEpay, verifyInfo.Type); err != nil {
-			c.Redirect(http.StatusFound, system_setting.ServerAddress+"/console/topup?pay=fail")
+			c.Redirect(http.StatusFound, system_setting.ServerAddress+"/wallet?pay=fail")
 			return
 		}
-		c.Redirect(http.StatusFound, system_setting.ServerAddress+"/console/topup?pay=success")
+		c.Redirect(http.StatusFound, system_setting.ServerAddress+"/wallet?pay=success")
 		return
 	}
-	c.Redirect(http.StatusFound, system_setting.ServerAddress+"/console/topup?pay=pending")
+	c.Redirect(http.StatusFound, system_setting.ServerAddress+"/wallet?pay=pending")
 }

--- a/controller/subscription_payment_stripe.go
+++ b/controller/subscription_payment_stripe.go
@@ -111,8 +111,8 @@ func genStripeSubscriptionLink(referenceId string, customerId string, email stri
 
 	params := &stripe.CheckoutSessionParams{
 		ClientReferenceID: stripe.String(referenceId),
-		SuccessURL:        stripe.String(system_setting.ServerAddress + "/console/topup"),
-		CancelURL:         stripe.String(system_setting.ServerAddress + "/console/topup"),
+		SuccessURL:        stripe.String(system_setting.ServerAddress + "/wallet"),
+		CancelURL:         stripe.String(system_setting.ServerAddress + "/wallet"),
 		LineItems: []*stripe.CheckoutSessionLineItemParams{
 			{
 				Price:    stripe.String(priceId),

--- a/controller/topup.go
+++ b/controller/topup.go
@@ -207,7 +207,7 @@ func RequestEpay(c *gin.Context) {
 	}
 
 	callBackAddress := service.GetCallbackAddress()
-	returnUrl, _ := url.Parse(system_setting.ServerAddress + "/console/log")
+	returnUrl, _ := url.Parse(system_setting.ServerAddress + "/usage-logs/common")
 	notifyUrl, _ := url.Parse(callBackAddress + "/api/user/epay/notify")
 	tradeNo := fmt.Sprintf("%s%d", common.GetRandomString(6), time.Now().Unix())
 	tradeNo = fmt.Sprintf("USR%dNO%s", id, tradeNo)

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -348,10 +348,10 @@ func genStripeLink(referenceId string, customerId string, email string, amount i
 
 	// Use custom URLs if provided, otherwise use defaults
 	if successURL == "" {
-		successURL = system_setting.ServerAddress + "/console/log"
+		successURL = system_setting.ServerAddress + "/usage-logs/common"
 	}
 	if cancelURL == "" {
-		cancelURL = system_setting.ServerAddress + "/console/topup"
+		cancelURL = system_setting.ServerAddress + "/wallet"
 	}
 
 	params := &stripe.CheckoutSessionParams{

--- a/controller/topup_waffo.go
+++ b/controller/topup_waffo.go
@@ -237,7 +237,7 @@ func RequestWaffoPay(c *gin.Context) {
 	if setting.WaffoNotifyUrl != "" {
 		notifyUrl = setting.WaffoNotifyUrl
 	}
-	returnUrl := system_setting.ServerAddress + "/console/topup?show_history=true"
+	returnUrl := system_setting.ServerAddress + "/wallet?show_history=true"
 	if setting.WaffoReturnUrl != "" {
 		returnUrl = setting.WaffoReturnUrl
 	}

--- a/controller/topup_waffo_pancake.go
+++ b/controller/topup_waffo_pancake.go
@@ -107,7 +107,7 @@ func getWaffoPancakeReturnURL() string {
 	if strings.TrimSpace(setting.WaffoPancakeReturnURL) != "" {
 		return setting.WaffoPancakeReturnURL
 	}
-	return strings.TrimRight(system_setting.ServerAddress, "/") + "/console/topup?show_history=true"
+	return strings.TrimRight(system_setting.ServerAddress, "/") + "/wallet?show_history=true"
 }
 
 func RequestWaffoPancakePay(c *gin.Context) {

--- a/epay/epay_sign_test.go
+++ b/epay/epay_sign_test.go
@@ -13,7 +13,7 @@ func TestSignEPayParamsMatchesGoEpay(t *testing.T) {
 		"type":         "alipay",
 		"out_trade_no": "USR1NOabc",
 		"notify_url":   "https://kittyvibe.ai/api/user/epay/notify",
-		"return_url":   "https://kittyvibe.ai/console/log",
+		"return_url":   "https://kittyvibe.ai/usage-logs/common",
 		"name":         "TUC10",
 		"money":        "7.30",
 		"device":       "pc",

--- a/epay/postgres_order_store_test.go
+++ b/epay/postgres_order_store_test.go
@@ -35,7 +35,7 @@ func TestPostgresOrderStoreContract(t *testing.T) {
 		Subject:     "TUC10",
 		Amount:      "7.30",
 		NotifyURL:   "https://kittyvibe.ai/api/user/epay/notify",
-		ReturnURL:   "https://kittyvibe.ai/console/log",
+		ReturnURL:   "https://kittyvibe.ai/usage-logs/common",
 	}
 
 	stored, existed, err := store.UpsertFromSubmit(order)

--- a/epay/server.go
+++ b/epay/server.go
@@ -182,7 +182,7 @@ func (g *Gateway) handleAlipayReturn(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	http.Redirect(w, r, "https://kittyvibe.ai/console/log", http.StatusFound)
+	http.Redirect(w, r, "https://kittyvibe.ai/usage-logs/common", http.StatusFound)
 }
 
 func (g *Gateway) processCallback(order *Order) {

--- a/epay/server_test.go
+++ b/epay/server_test.go
@@ -103,7 +103,7 @@ func TestAlipayNotifyCallbacksNewAPIOnce(t *testing.T) {
 		Subject:     "TUC10",
 		Amount:      "7.30",
 		NotifyURL:   newAPIServer.URL,
-		ReturnURL:   "https://kittyvibe.ai/console/log",
+		ReturnURL:   "https://kittyvibe.ai/usage-logs/common",
 	})
 	require.NoError(t, err)
 
@@ -139,7 +139,7 @@ func TestAlipayNotifyRejectsAmountMismatch(t *testing.T) {
 		Subject:     "TUC10",
 		Amount:      "7.30",
 		NotifyURL:   "https://kittyvibe.ai/api/user/epay/notify",
-		ReturnURL:   "https://kittyvibe.ai/console/log",
+		ReturnURL:   "https://kittyvibe.ai/usage-logs/common",
 	})
 	require.NoError(t, err)
 

--- a/epay/test_helpers_test.go
+++ b/epay/test_helpers_test.go
@@ -53,7 +53,7 @@ func signedEPayForm(cfg Config, overrides map[string]string) url.Values {
 		"type":         "alipay",
 		"out_trade_no": "USR1NOabc",
 		"notify_url":   "https://kittyvibe.ai/api/user/epay/notify",
-		"return_url":   "https://kittyvibe.ai/console/log",
+		"return_url":   "https://kittyvibe.ai/usage-logs/common",
 		"name":         "TUC10",
 		"money":        "7.30",
 		"device":       "pc",

--- a/service/quota.go
+++ b/service/quota.go
@@ -463,7 +463,7 @@ func checkAndSendQuotaNotify(relayInfo *relaycommon.RelayInfo, quota int, preCon
 		}
 		if quotaTooLow {
 			prompt := "您的额度即将用尽"
-			topUpLink := fmt.Sprintf("%s/console/topup", system_setting.ServerAddress)
+			topUpLink := fmt.Sprintf("%s/wallet", system_setting.ServerAddress)
 
 			// 根据通知方式生成不同的内容格式
 			var content string
@@ -517,7 +517,7 @@ func checkAndSendSubscriptionQuotaNotify(relayInfo *relaycommon.RelayInfo) {
 		}
 
 		prompt := "您的订阅额度即将用尽"
-		topUpLink := fmt.Sprintf("%s/console/topup", system_setting.ServerAddress)
+		topUpLink := fmt.Sprintf("%s/wallet", system_setting.ServerAddress)
 
 		var content string
 		var values []interface{}

--- a/web/default/src/features/system-settings/integrations/waffo-pancake-settings-section.tsx
+++ b/web/default/src/features/system-settings/integrations/waffo-pancake-settings-section.tsx
@@ -232,7 +232,7 @@ export function WaffoPancakeSettingsSection(props: Props) {
         <div className='grid gap-1.5'>
           <Label>{t('Payment return URL')}</Label>
           <Input
-            placeholder='https://example.com/console/topup'
+            placeholder='https://example.com/wallet'
             {...form.register('WaffoPancakeReturnURL')}
           />
           <p className='text-muted-foreground text-xs'>

--- a/web/default/src/features/system-settings/integrations/waffo-settings-section.tsx
+++ b/web/default/src/features/system-settings/integrations/waffo-settings-section.tsx
@@ -310,7 +310,7 @@ export function WaffoSettingsSection(props: Props) {
           <div className='grid gap-1.5'>
             <Label>{t('Payment return URL')}</Label>
             <Input
-              placeholder='https://example.com/console/topup'
+              placeholder='https://example.com/wallet'
               {...form.register('WaffoReturnUrl')}
             />
           </div>


### PR DESCRIPTION
## Why
After Alipay (and Stripe / Waffo / subscription Epay / etc.) payments complete, the gateway was redirecting users to \`/console/log\` and \`/console/topup\` — these are URLs from the upstream new-api frontend that don't exist in the KittyVibe default frontend. Result: **users hit a 404 right after a successful payment.**

User report from production:
> 我支付宝充值完成之后，它跳转到了一个 404 页面 https://kittyvibe.ai/console/log

## Mapping
| Old (404)                                        | New                                       |
|--------------------------------------------------|-------------------------------------------|
| \`/console/log\`                                   | \`/usage-logs/common\`                      |
| \`/console/topup\`                                 | \`/wallet\`                                 |
| \`/console/topup?show_history=true\`               | \`/wallet?show_history=true\`               |
| \`/console/topup?pay=fail\|success\|pending\`        | \`/wallet?pay=fail\|success\|pending\`        |

The \`?show_history=true\` param is read by Wallet today (auto-opens billing history dialog). The \`?pay=*\` params are passed through unchanged — Wallet ignores them for now, but they're preserved so a future toast can act on them without another round-trip.

## Files
- \`controller/topup.go\` — Epay
- \`controller/topup_stripe.go\` — Stripe success/cancel URLs
- \`controller/topup_waffo.go\` — Waffo
- \`controller/topup_waffo_pancake.go\` — Waffo Pancake fallback
- \`controller/subscription_payment_epay.go\` — subscription pay outcomes (5 redirects)
- \`controller/subscription_payment_stripe.go\` — subscription Stripe URLs
- \`service/quota.go\` — low-balance email link
- \`epay/server.go\` — Alipay return fallback when order has no return_url
- \`web/default/src/features/system-settings/integrations/waffo*-settings-section.tsx\` — admin form placeholders
- \`epay/*_test.go\` — test fixtures (kept consistent)

## Out of scope
While sweeping, I noticed three more stale \`/console/*\` paths that are *not* payment-related — leaving them for separate PRs since they're independent bugs:
- \`controller/telegram.go\` — \`/console/personal\` (should be \`/profile\`)
- \`web/default/src/features/playground/components/message-error.tsx\` and channel-test dialogs — \`/console/setting?tab=ratio\`
- \`web/default/src/features/channels/components/channels-columns.tsx\` — \`/console/deployment\`

## Test plan
- [x] \`go build ./...\` clean (modulo \`web/default/dist\` embed pattern)
- [x] \`go test ./model/ ./epay/\` clean
- [ ] After deploy: trigger a small Epay test top-up → confirm post-payment redirect lands on \`/usage-logs/common\` not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)