### PR TITLE
fix(doubao): honour Seedance ratio parameters (#60)

### DIFF
--- a/relay/channel/task/doubao/adaptor.go
+++ b/relay/channel/task/doubao/adaptor.go
@@ -373,6 +373,19 @@ func (a *TaskAdaptor) GetChannelName() string {
 	return ChannelName
 }
 
+// looksLikeAspectRatio reports whether s is shaped like "X:Y" with positive
+// integer parts (e.g. "16:9", "9:16", "1:1"). Volc Ark's `ratio` accepts this
+// form; "WxH" pixel sizes go to `resolution` instead.
+func looksLikeAspectRatio(s string) bool {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	a, errA := strconv.Atoi(strings.TrimSpace(parts[0]))
+	b, errB := strconv.Atoi(strings.TrimSpace(parts[1]))
+	return errA == nil && errB == nil && a > 0 && b > 0
+}
+
 func (a *TaskAdaptor) convertToRequestPayload(req *relaycommon.TaskSubmitReq) (*requestPayload, error) {
 	r := requestPayload{
 		Model:   req.Model,
@@ -397,11 +410,25 @@ func (a *TaskAdaptor) convertToRequestPayload(req *relaycommon.TaskSubmitReq) (*
 	}
 
 	// Honour top-level passthrough fields when metadata didn't already set them.
-	// OpenAI Videos clients put `resolution` and numeric `duration` at the root
-	// of the request body; without this fallback the upstream Volcano Ark API
-	// receives nothing and silently substitutes its defaults (720p, 5s).
+	// OpenAI Videos clients put `resolution`, `ratio` and numeric `duration` at
+	// the root of the request body; without this fallback the upstream Volcano
+	// Ark API receives nothing and silently substitutes its defaults (720p, 5s,
+	// ratio=auto). Some clients also overload `size` with either a "WxH" pixel
+	// pair (resolution) or an "X:Y" aspect ratio — accept both forms.
 	if r.Resolution == "" && req.Resolution != "" {
 		r.Resolution = req.Resolution
+	}
+	if r.Ratio == "" && req.Ratio != "" {
+		r.Ratio = req.Ratio
+	}
+	if size := strings.TrimSpace(req.Size); size != "" {
+		if looksLikeAspectRatio(size) {
+			if r.Ratio == "" {
+				r.Ratio = size
+			}
+		} else if r.Resolution == "" {
+			r.Resolution = size
+		}
 	}
 	if r.Duration == nil {
 		if req.Duration > 0 {

--- a/relay/channel/task/doubao/adaptor.go
+++ b/relay/channel/task/doubao/adaptor.go
@@ -122,7 +122,7 @@ func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
 //
 //   - first_frame + last_frame  → firstTailGenerate (首尾生视频)
 //   - any video_url             → referenceGenerate (参照生视频, covers
-//                                  multi-modal / edit / extend)
+//     multi-modal / edit / extend)
 //   - any image_url             → generate (图生视频)
 //   - text only                 → textGenerate (文生视频)
 //
@@ -410,16 +410,21 @@ func (a *TaskAdaptor) convertToRequestPayload(req *relaycommon.TaskSubmitReq) (*
 	}
 
 	// Honour top-level passthrough fields when metadata didn't already set them.
-	// OpenAI Videos clients put `resolution`, `ratio` and numeric `duration` at
-	// the root of the request body; without this fallback the upstream Volcano
-	// Ark API receives nothing and silently substitutes its defaults (720p, 5s,
-	// ratio=auto). Some clients also overload `size` with either a "WxH" pixel
-	// pair (resolution) or an "X:Y" aspect ratio — accept both forms.
+	// OpenAI Videos clients put `resolution`, `ratio`/`aspect_ratio` and numeric
+	// `duration` at the root of the request body; without this fallback the
+	// upstream Volcano Ark API receives nothing and silently substitutes its
+	// defaults (720p, 5s, ratio=auto). Some clients also overload `size` with
+	// either a "WxH" pixel pair (resolution) or an "X:Y" aspect ratio — accept
+	// both forms.
 	if r.Resolution == "" && req.Resolution != "" {
 		r.Resolution = req.Resolution
 	}
-	if r.Ratio == "" && req.Ratio != "" {
-		r.Ratio = req.Ratio
+	if r.Ratio == "" {
+		if req.Ratio != "" {
+			r.Ratio = req.Ratio
+		} else if req.AspectRatio != "" {
+			r.Ratio = req.AspectRatio
+		}
 	}
 	if size := strings.TrimSpace(req.Size); size != "" {
 		if looksLikeAspectRatio(size) {

--- a/relay/channel/task/doubao/adaptor_test.go
+++ b/relay/channel/task/doubao/adaptor_test.go
@@ -3,6 +3,7 @@ package doubao
 import (
 	"testing"
 
+	"github.com/QuantumNous/new-api/common"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/stretchr/testify/require"
 )
@@ -93,6 +94,30 @@ func TestConvertToRequestPayloadHonoursTopLevelRatio(t *testing.T) {
 			Prompt:   "p",
 			Ratio:    "9:16",
 			Metadata: map[string]any{"ratio": "16:9"},
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.Equal(t, "16:9", body.Ratio)
+	})
+
+	t.Run("top-level aspect_ratio alias flows through", func(t *testing.T) {
+		var req relaycommon.TaskSubmitReq
+		require.NoError(t, common.Unmarshal([]byte(`{
+			"model": "doubao-seedance-2-0-260128",
+			"prompt": "p",
+			"aspect_ratio": "9:16"
+		}`), &req))
+		body, err := a.convertToRequestPayload(&req)
+		require.NoError(t, err)
+		require.Equal(t, "9:16", body.Ratio)
+	})
+
+	t.Run("ratio wins over aspect_ratio alias", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:       "doubao-seedance-2-0-260128",
+			Prompt:      "p",
+			Ratio:       "16:9",
+			AspectRatio: "9:16",
 		}
 		body, err := a.convertToRequestPayload(req)
 		require.NoError(t, err)

--- a/relay/channel/task/doubao/adaptor_test.go
+++ b/relay/channel/task/doubao/adaptor_test.go
@@ -172,3 +172,43 @@ func TestConvertToRequestPayloadHonoursTopLevelRatio(t *testing.T) {
 		require.Equal(t, "16:9", body.Ratio)
 	})
 }
+
+func TestConvertToRequestPayloadKeepsSizeHandlingLimitedToCurrentBug(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		wantResolution string
+		wantRatio      string
+	}{
+		{
+			name:           "pixel size remains resolution fallback",
+			body:           `{"model":"doubao-seedance-2-0-260128","prompt":"p","size":"1280x720"}`,
+			wantResolution: "1280x720",
+			wantRatio:      "",
+		},
+		{
+			name:           "aspect ratio size alias",
+			body:           `{"model":"doubao-seedance-2-0-260128","prompt":"p","size":"9:16"}`,
+			wantResolution: "",
+			wantRatio:      "9:16",
+		},
+		{
+			name:           "aspect_ratio alias",
+			body:           `{"model":"doubao-seedance-2-0-260128","prompt":"p","aspect_ratio":"3:4"}`,
+			wantResolution: "",
+			wantRatio:      "3:4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req relaycommon.TaskSubmitReq
+			require.NoError(t, common.Unmarshal([]byte(tt.body), &req))
+
+			body, err := (&TaskAdaptor{}).convertToRequestPayload(&req)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantResolution, body.Resolution)
+			require.Equal(t, tt.wantRatio, body.Ratio)
+		})
+	}
+}

--- a/relay/channel/task/doubao/adaptor_test.go
+++ b/relay/channel/task/doubao/adaptor_test.go
@@ -66,5 +66,84 @@ func TestConvertToRequestPayloadHonoursTopLevelDurationAndResolution(t *testing.
 		require.NoError(t, err)
 		require.Nil(t, body.Duration)
 		require.Equal(t, "", body.Resolution)
+		require.Equal(t, "", body.Ratio)
+	})
+}
+
+// Top-level `ratio` must reach upstream Volcano Ark; otherwise the API
+// silently picks "auto" and the caller's aspect ratio is discarded. See
+// https://github.com/NekoAIKan/aikanhub/issues/60.
+func TestConvertToRequestPayloadHonoursTopLevelRatio(t *testing.T) {
+	a := &TaskAdaptor{}
+
+	t.Run("top-level ratio flows through", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:  "doubao-seedance-2-0-260128",
+			Prompt: "p",
+			Ratio:  "9:16",
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.Equal(t, "9:16", body.Ratio)
+	})
+
+	t.Run("metadata ratio overrides top-level", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:    "doubao-seedance-2-0-260128",
+			Prompt:   "p",
+			Ratio:    "9:16",
+			Metadata: map[string]any{"ratio": "16:9"},
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.Equal(t, "16:9", body.Ratio)
+	})
+
+	t.Run("size carries pixel pair into resolution", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:  "doubao-seedance-2-0-260128",
+			Prompt: "p",
+			Size:   "1280x720",
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.Equal(t, "1280x720", body.Resolution)
+		require.Equal(t, "", body.Ratio)
+	})
+
+	t.Run("size carries aspect ratio into ratio", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:  "doubao-seedance-2-0-260128",
+			Prompt: "p",
+			Size:   "9:16",
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.Equal(t, "9:16", body.Ratio)
+		require.Equal(t, "", body.Resolution)
+	})
+
+	t.Run("explicit resolution wins over size", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:      "doubao-seedance-2-0-260128",
+			Prompt:     "p",
+			Resolution: "480p",
+			Size:       "1920x1080",
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.Equal(t, "480p", body.Resolution)
+	})
+
+	t.Run("explicit ratio wins over size ratio", func(t *testing.T) {
+		req := &relaycommon.TaskSubmitReq{
+			Model:  "doubao-seedance-2-0-260128",
+			Prompt: "p",
+			Ratio:  "16:9",
+			Size:   "9:16",
+		}
+		body, err := a.convertToRequestPayload(req)
+		require.NoError(t, err)
+		require.Equal(t, "16:9", body.Ratio)
 	})
 }

--- a/relay/channel/task/doubao/billing.go
+++ b/relay/channel/task/doubao/billing.go
@@ -174,6 +174,8 @@ func resolveRequestVideoDimensions(profile videobilling.VideoBillingProfile, req
 		stringFromMap(req.Metadata, "aspect_ratio"),
 		req.Ratio,
 		req.AspectRatio,
+		aspectRatioFromSize(req.Size),
+		aspectRatioFromSize(stringFromMap(req.Metadata, "size")),
 	)
 	if resolution != "" || ratio != "" {
 		return resolveVideoDimensionsWithRatio(profile, firstString(resolution, req.Size, stringFromMap(req.Metadata, "size")), ratio)
@@ -184,6 +186,14 @@ func resolveRequestVideoDimensions(profile videobilling.VideoBillingProfile, req
 		}
 	}
 	return resolveVideoDimensionsWithRatio(profile, firstString(req.Size, stringFromMap(req.Metadata, "size")), ratio)
+}
+
+func aspectRatioFromSize(size string) string {
+	size = strings.TrimSpace(size)
+	if looksLikeAspectRatio(size) {
+		return size
+	}
+	return ""
 }
 
 func resolveVideoDimensionsWithRatio(profile videobilling.VideoBillingProfile, raw string, ratio string) (int, int) {

--- a/relay/channel/task/doubao/billing.go
+++ b/relay/channel/task/doubao/billing.go
@@ -1,6 +1,7 @@
 package doubao
 
 import (
+	"math"
 	"strconv"
 	"strings"
 
@@ -13,8 +14,8 @@ import (
 
 func ExtractRequestBillingInput(req relaycommon.TaskSubmitReq, profile videobilling.VideoBillingProfile, groupRatio float64) service.VideoBillingInput {
 	outputSeconds := firstPositiveInt(intFromMap(req.Metadata, "duration"), req.Duration, atoi(req.Seconds), intFromMap(req.Metadata, "seconds"))
-	resolution := firstString(stringFromMap(req.Metadata, "resolution"), req.Resolution, req.Size, stringFromMap(req.Metadata, "size"))
-	width, height := resolveVideoDimensions(profile, resolution)
+	resolution := requestBillingResolution(req)
+	width, height := resolveRequestVideoDimensions(profile, req)
 	fps := firstPositiveInt(intFromMap(req.Metadata, "fps"), intFromMap(req.Metadata, "framespersecond"), profile.FallbackFPS)
 	draft := boolFromMap(req.Metadata, "draft")
 
@@ -39,7 +40,7 @@ func ExtractRequestBillingInput(req relaycommon.TaskSubmitReq, profile videobill
 		Width:             width,
 		Height:            height,
 		FPS:               fps,
-		Resolution:        normalizeResolutionAlias(resolution),
+		Resolution:        resolution,
 		GroupRatio:        groupRatio,
 		Draft:             draft,
 		HasReferenceMedia: hasReferenceMedia,
@@ -51,7 +52,7 @@ func ExtractResponseBillingInput(body []byte, profile videobilling.VideoBillingP
 	if err := common.Unmarshal(body, &resTask); err != nil {
 		return service.VideoBillingInput{}, err
 	}
-	width, height := resolveVideoDimensions(profile, resTask.Resolution)
+	width, height := resolveVideoDimensionsWithRatio(profile, resTask.Resolution, resTask.Ratio)
 	fps := firstPositiveInt(resTask.FramesPerSecond, profile.FallbackFPS)
 	return service.VideoBillingInput{
 		OutputSeconds:       firstPositiveInt(resTask.Duration, profile.FallbackDurationSeconds),
@@ -62,6 +63,20 @@ func ExtractResponseBillingInput(body []byte, profile videobilling.VideoBillingP
 		GroupRatio:          groupRatio,
 		UpstreamTotalTokens: resTask.Usage.TotalTokens,
 	}, nil
+}
+
+func requestBillingResolution(req relaycommon.TaskSubmitReq) string {
+	if resolution := firstString(stringFromMap(req.Metadata, "resolution"), req.Resolution); resolution != "" {
+		return normalizeResolutionAlias(resolution)
+	}
+	for _, size := range []string{req.Size, stringFromMap(req.Metadata, "size")} {
+		size = strings.TrimSpace(size)
+		if size == "" || looksLikeAspectRatio(size) {
+			continue
+		}
+		return normalizeResolutionAlias(size)
+	}
+	return ""
 }
 
 func normalizeResolutionAlias(raw string) string {
@@ -149,6 +164,50 @@ func mergeVideoBillingInput(base, override service.VideoBillingInput) service.Vi
 }
 
 func resolveVideoDimensions(profile videobilling.VideoBillingProfile, raw string) (int, int) {
+	return resolveVideoDimensionsWithRatio(profile, raw, "")
+}
+
+func resolveRequestVideoDimensions(profile videobilling.VideoBillingProfile, req relaycommon.TaskSubmitReq) (int, int) {
+	resolution := firstString(stringFromMap(req.Metadata, "resolution"), req.Resolution)
+	ratio := firstString(
+		stringFromMap(req.Metadata, "ratio"),
+		stringFromMap(req.Metadata, "aspect_ratio"),
+		req.Ratio,
+		req.AspectRatio,
+	)
+	if resolution != "" || ratio != "" {
+		return resolveVideoDimensionsWithRatio(profile, firstString(resolution, req.Size, stringFromMap(req.Metadata, "size")), ratio)
+	}
+	for _, size := range []string{req.Size, stringFromMap(req.Metadata, "size")} {
+		if width, height, ok := parseResolutionPair(size); ok {
+			return width, height
+		}
+	}
+	return resolveVideoDimensionsWithRatio(profile, firstString(req.Size, stringFromMap(req.Metadata, "size")), ratio)
+}
+
+func resolveVideoDimensionsWithRatio(profile videobilling.VideoBillingProfile, raw string, ratio string) (int, int) {
+	width, height := resolveVideoDimensionsBase(profile, raw)
+	if ratio == "" || ratio == "adaptive" {
+		return width, height
+	}
+	ratioWidth, ratioHeight, ok := parseAspectRatio(ratio)
+	if !ok {
+		return width, height
+	}
+	area := float64(width * height)
+	if area <= 0 {
+		return width, height
+	}
+	adjustedWidth := int(math.Round(math.Sqrt(area * float64(ratioWidth) / float64(ratioHeight))))
+	adjustedHeight := int(math.Round(math.Sqrt(area * float64(ratioHeight) / float64(ratioWidth))))
+	if adjustedWidth <= 0 || adjustedHeight <= 0 {
+		return width, height
+	}
+	return adjustedWidth, adjustedHeight
+}
+
+func resolveVideoDimensionsBase(profile videobilling.VideoBillingProfile, raw string) (int, int) {
 	if raw != "" {
 		key := strings.ToLower(strings.TrimSpace(raw))
 		for alias, resolution := range profile.ResolutionAliases {
@@ -161,6 +220,19 @@ func resolveVideoDimensions(profile videobilling.VideoBillingProfile, raw string
 		}
 	}
 	return profile.FallbackWidth, profile.FallbackHeight
+}
+
+func parseAspectRatio(raw string) (int, int, bool) {
+	parts := strings.SplitN(strings.TrimSpace(raw), ":", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	width, errWidth := strconv.Atoi(strings.TrimSpace(parts[0]))
+	height, errHeight := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if errWidth != nil || errHeight != nil || width <= 0 || height <= 0 {
+		return 0, 0, false
+	}
+	return width, height, true
 }
 
 func parseResolutionPair(raw string) (int, int, bool) {

--- a/relay/channel/task/doubao/billing_test.go
+++ b/relay/channel/task/doubao/billing_test.go
@@ -175,8 +175,15 @@ func TestExtractRequestBillingInputAlignsResolutionRatioAndSize(t *testing.T) {
 			req: relaycommon.TaskSubmitReq{
 				Duration: 5,
 				Size:     "9:16",
+			},
+			want: service.VideoBillingInput{OutputSeconds: 5, Width: 720, Height: 1280, FPS: 24, GroupRatio: 1},
+		},
+		{
+			name: "metadata aspect ratio size is captured",
+			req: relaycommon.TaskSubmitReq{
+				Duration: 5,
 				Metadata: map[string]any{
-					"ratio": "9:16",
+					"size": "9:16",
 				},
 			},
 			want: service.VideoBillingInput{OutputSeconds: 5, Width: 720, Height: 1280, FPS: 24, GroupRatio: 1},
@@ -189,6 +196,25 @@ func TestExtractRequestBillingInputAlignsResolutionRatioAndSize(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestExtractRequestBillingInputUsesConfiguredFallbackForSizeRatio(t *testing.T) {
+	profile := testProfile()
+	profile.FallbackWidth = 640
+	profile.FallbackHeight = 360
+
+	got := ExtractRequestBillingInput(relaycommon.TaskSubmitReq{
+		Duration: 5,
+		Size:     "9:16",
+	}, profile, 1)
+
+	require.Equal(t, service.VideoBillingInput{
+		OutputSeconds: 5,
+		Width:         360,
+		Height:        640,
+		FPS:           24,
+		GroupRatio:    1,
+	}, got)
 }
 
 func TestExtractRequestBillingInputMarksReferenceMedia(t *testing.T) {

--- a/relay/channel/task/doubao/billing_test.go
+++ b/relay/channel/task/doubao/billing_test.go
@@ -133,6 +133,64 @@ func TestExtractRequestBillingInputMetadataOverridesTopLevel(t *testing.T) {
 	}, got)
 }
 
+func TestExtractRequestBillingInputAlignsResolutionRatioAndSize(t *testing.T) {
+	tests := []struct {
+		name string
+		req  relaycommon.TaskSubmitReq
+		want service.VideoBillingInput
+	}{
+		{
+			name: "metadata resolution and portrait ratio",
+			req: relaycommon.TaskSubmitReq{
+				Duration: 5,
+				Metadata: map[string]any{
+					"resolution": "720p",
+					"ratio":      "9:16",
+				},
+			},
+			want: service.VideoBillingInput{OutputSeconds: 5, Width: 720, Height: 1280, FPS: 24, Resolution: "720p", GroupRatio: 1},
+		},
+		{
+			name: "top-level landscape pixel size",
+			req: relaycommon.TaskSubmitReq{
+				Duration: 5,
+				Size:     "1280x720",
+			},
+			want: service.VideoBillingInput{OutputSeconds: 5, Width: 1280, Height: 720, FPS: 24, Resolution: "1280x720", GroupRatio: 1},
+		},
+		{
+			name: "normalized portrait size metadata",
+			req: relaycommon.TaskSubmitReq{
+				Duration: 5,
+				Size:     "720x1280",
+				Metadata: map[string]any{
+					"resolution": "720p",
+					"ratio":      "9:16",
+				},
+			},
+			want: service.VideoBillingInput{OutputSeconds: 5, Width: 720, Height: 1280, FPS: 24, Resolution: "720p", GroupRatio: 1},
+		},
+		{
+			name: "aspect ratio size is not treated as resolution",
+			req: relaycommon.TaskSubmitReq{
+				Duration: 5,
+				Size:     "9:16",
+				Metadata: map[string]any{
+					"ratio": "9:16",
+				},
+			},
+			want: service.VideoBillingInput{OutputSeconds: 5, Width: 720, Height: 1280, FPS: 24, GroupRatio: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractRequestBillingInput(tt.req, testProfile(), 1)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestExtractRequestBillingInputMarksReferenceMedia(t *testing.T) {
 	got := ExtractRequestBillingInput(relaycommon.TaskSubmitReq{
 		Duration: 5,
@@ -192,6 +250,25 @@ func TestExtractResponseBillingInput(t *testing.T) {
 		GroupRatio:          1,
 		UpstreamTotalTokens: 12345,
 	}, got)
+}
+
+func TestExtractResponseBillingInputUsesReturnedRatio(t *testing.T) {
+	body := []byte(`{
+		"id": "task-upstream",
+		"status": "succeeded",
+		"resolution": "720p",
+		"ratio": "9:16",
+		"duration": 5,
+		"framespersecond": 24,
+		"usage": {"total_tokens": 1000}
+	}`)
+
+	got, err := ExtractResponseBillingInput(body, testProfile(), 1)
+	require.NoError(t, err)
+	require.Equal(t, 720, got.Width)
+	require.Equal(t, 1280, got.Height)
+	require.Equal(t, 5, got.OutputSeconds)
+	require.Equal(t, "720p", got.Resolution)
 }
 
 func TestAdjustBillingOnCompleteUsesProfileContextAndResponse(t *testing.T) {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -674,22 +674,24 @@ type TaskRelayInfo struct {
 }
 
 type TaskSubmitReq struct {
-	Prompt         string                   `json:"prompt"`
-	Model          string                   `json:"model,omitempty"`
-	Mode           string                   `json:"mode,omitempty"`
-	Image          string                   `json:"image,omitempty"`
-	Images         []string                 `json:"images,omitempty"`
-	Content        []map[string]interface{} `json:"content,omitempty"`
-	Size           string                   `json:"size,omitempty"`
-	Resolution     string                   `json:"resolution,omitempty"`
-	// Ratio is the aspect ratio (e.g. "16:9", "9:16", "1:1"). Doubao/BytePlus
-	// video accepts this as a top-level field; without it the upstream
-	// silently substitutes "auto" and ignores the user's choice.
-	Ratio          string                   `json:"ratio,omitempty"`
-	Duration       int                      `json:"duration,omitempty"`
-	Seconds        string                   `json:"seconds,omitempty"`
-	InputReference string                   `json:"input_reference,omitempty"`
-	Metadata       map[string]interface{}   `json:"metadata,omitempty"`
+	Prompt     string                   `json:"prompt"`
+	Model      string                   `json:"model,omitempty"`
+	Mode       string                   `json:"mode,omitempty"`
+	Image      string                   `json:"image,omitempty"`
+	Images     []string                 `json:"images,omitempty"`
+	Content    []map[string]interface{} `json:"content,omitempty"`
+	Size       string                   `json:"size,omitempty"`
+	Resolution string                   `json:"resolution,omitempty"`
+	// Ratio is the aspect ratio (e.g. "16:9", "9:16", "1:1"). AspectRatio is
+	// accepted as a compatibility alias for clients that use `aspect_ratio`.
+	// Doubao/BytePlus video accepts this as a top-level field; without it the
+	// upstream silently substitutes "auto" and ignores the user's choice.
+	Ratio          string                 `json:"ratio,omitempty"`
+	AspectRatio    string                 `json:"aspect_ratio,omitempty"`
+	Duration       int                    `json:"duration,omitempty"`
+	Seconds        string                 `json:"seconds,omitempty"`
+	InputReference string                 `json:"input_reference,omitempty"`
+	Metadata       map[string]interface{} `json:"metadata,omitempty"`
 }
 
 func (t *TaskSubmitReq) GetPrompt() string {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -682,6 +682,10 @@ type TaskSubmitReq struct {
 	Content        []map[string]interface{} `json:"content,omitempty"`
 	Size           string                   `json:"size,omitempty"`
 	Resolution     string                   `json:"resolution,omitempty"`
+	// Ratio is the aspect ratio (e.g. "16:9", "9:16", "1:1"). Doubao/BytePlus
+	// video accepts this as a top-level field; without it the upstream
+	// silently substitutes "auto" and ignores the user's choice.
+	Ratio          string                   `json:"ratio,omitempty"`
 	Duration       int                      `json:"duration,omitempty"`
 	Seconds        string                   `json:"seconds,omitempty"`
 	InputReference string                   `json:"input_reference,omitempty"`

--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -145,6 +145,7 @@ func validateMultipartTaskRequest(c *gin.Context, info *RelayInfo, action string
 		Image:      formData.Get("image"),
 		Size:       formData.Get("size"),
 		Resolution: formData.Get("resolution"),
+		Ratio:      formData.Get("ratio"),
 		Metadata:   make(map[string]interface{}),
 	}
 
@@ -253,6 +254,7 @@ func isKnownTaskField(field string) bool {
 		"images":          true,
 		"size":            true,
 		"resolution":      true,
+		"ratio":           true,
 		"duration":        true,
 		"input_reference": true, // Sora 特有字段
 	}

--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -139,14 +139,15 @@ func validateMultipartTaskRequest(c *gin.Context, info *RelayInfo, action string
 
 	formData := c.Request.PostForm
 	req = TaskSubmitReq{
-		Prompt:     formData.Get("prompt"),
-		Model:      formData.Get("model"),
-		Mode:       formData.Get("mode"),
-		Image:      formData.Get("image"),
-		Size:       formData.Get("size"),
-		Resolution: formData.Get("resolution"),
-		Ratio:      formData.Get("ratio"),
-		Metadata:   make(map[string]interface{}),
+		Prompt:      formData.Get("prompt"),
+		Model:       formData.Get("model"),
+		Mode:        formData.Get("mode"),
+		Image:       formData.Get("image"),
+		Size:        formData.Get("size"),
+		Resolution:  formData.Get("resolution"),
+		Ratio:       formData.Get("ratio"),
+		AspectRatio: formData.Get("aspect_ratio"),
+		Metadata:    make(map[string]interface{}),
 	}
 
 	if durationStr := formData.Get("seconds"); durationStr != "" {
@@ -255,6 +256,7 @@ func isKnownTaskField(field string) bool {
 		"size":            true,
 		"resolution":      true,
 		"ratio":           true,
+		"aspect_ratio":    true,
 		"duration":        true,
 		"input_reference": true, // Sora 特有字段
 	}

--- a/relay/common/relay_utils_test.go
+++ b/relay/common/relay_utils_test.go
@@ -88,3 +88,8 @@ func TestImagesFromMetadataContent(t *testing.T) {
 		})
 	}
 }
+
+func TestKnownTaskFieldsIncludesAspectRatioAlias(t *testing.T) {
+	require.True(t, isKnownTaskField("ratio"))
+	require.True(t, isKnownTaskField("aspect_ratio"))
+}


### PR DESCRIPTION
## Summary
- Preserve top-level `ratio` and `aspect_ratio` on Doubao/Seedance video requests so upstream no longer falls back to `auto`.
- Keep `size` handling limited to the existing parameter bug: `X:Y` is treated as a ratio alias, while `WxH` remains a resolution fallback without hard-coded resolution tier mapping.
- Align video billing dimensions with the resolved request/response ratio using the saved `video_billing_setting.profiles` data from the Credits & Profit settings page.
- Capture `size: "X:Y"` and `metadata.size: "X:Y"` in request billing so the precharge uses the configured fallback/alias dimensions with the requested aspect ratio.

## Tests
- go test ./relay/channel/task/doubao/...
- go test ./relay/...
- go test ./...
- git diff --check