### PR TITLE
fix(channels): surface Doubao/BytePlus task models in /api/channel/models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,8 +323,9 @@ When adding a new channel `constant.ChannelTypeXxx`:
 1. Add it to the appropriate `case` in `GetEndpointTypesByChannelType` (e.g. video task channels join the same case clause as `ChannelTypeSora` / `ChannelTypeDoubaoVideo`).
 2. If it's a video task channel, also confirm `pkg/billingexpr` / `setting/video_billing_setting` etc. handle the model id naturally (no per-vendor enum to extend).
 3. Manually verify on `/pricing`: the model's badge shows `Video` (not `Chat`), the endpoint type column shows `openai-video`, the sidebar `视频 N` count includes it.
+4. **Register the channel's `ModelList` in `controller/model.go::init()`.** Task-only channels are reached via `GetTaskAdaptor`, not `GetAdaptor`, so the `APIType` loop in `init()` never picks up their model lists. You must add two explicit lines next to the `taskpixverse` block: one appending to `openAIModels` (with `OwnedBy: taskXxx.ChannelName`), one setting `channelId2Models[constant.ChannelTypeXxx] = taskXxx.ModelList`. Skipping this means `/api/channel/models` omits the models, so the channel-create form's "Fill Related Models" button and custom-model autocomplete never suggest them — the operator has to know the exact model id and paste it blind. (Routing still works if pasted manually; this is purely the suggestion/discovery surface. Pixverse, Doubao, and BytePlus all hit this — only Pixverse was registered until BytePlus exposed the gap.)
 
-Skipping step 1 caught us once; the symptoms surface in the user-facing pricing page rather than the API path so it's easy to miss until a customer asks.
+Skipping step 1 caught us once; the symptoms surface in the user-facing pricing page rather than the API path so it's easy to miss until a customer asks. Step 4 caught us again with BytePlus — the symptom is "model missing from the channel-form dropdown" reported by an operator configuring production.
 
 ### Rule 22: One USD-to-local rate — `USDExchangeRate` is the single source of truth
 

--- a/controller/model.go
+++ b/controller/model.go
@@ -14,6 +14,8 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel/lingyiwanwu"
 	"github.com/QuantumNous/new-api/relay/channel/minimax"
 	"github.com/QuantumNous/new-api/relay/channel/moonshot"
+	taskbyteplus "github.com/QuantumNous/new-api/relay/channel/task/byteplus"
+	taskdoubao "github.com/QuantumNous/new-api/relay/channel/task/doubao"
 	taskpixverse "github.com/QuantumNous/new-api/relay/channel/task/pixverse"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
@@ -88,6 +90,27 @@ func init() {
 			OwnedBy: taskpixverse.ChannelName,
 		})
 	}
+	// Doubao (CN) + BytePlus (overseas) Seedance are task-only channels
+	// reached via GetTaskAdaptor, so the APIType loop above never picks
+	// up their model lists. Register them explicitly — same gap Pixverse
+	// had — otherwise the channel form's "Fill Related Models" button and
+	// the custom-model autocomplete never suggest seedance-* ids.
+	for _, modelName := range taskdoubao.ModelList {
+		openAIModels = append(openAIModels, dto.OpenAIModels{
+			Id:      modelName,
+			Object:  "model",
+			Created: 1626777600,
+			OwnedBy: taskdoubao.ChannelName,
+		})
+	}
+	for _, modelName := range taskbyteplus.ModelList {
+		openAIModels = append(openAIModels, dto.OpenAIModels{
+			Id:      modelName,
+			Object:  "model",
+			Created: 1626777600,
+			OwnedBy: taskbyteplus.ChannelName,
+		})
+	}
 	for modelName, _ := range constant.MidjourneyModel2Action {
 		openAIModels = append(openAIModels, dto.OpenAIModels{
 			Id:      modelName,
@@ -117,6 +140,8 @@ func init() {
 	// their models surface in /api/channel/models and the channel form's
 	// "Fill Related Models" suggestion list.
 	channelId2Models[constant.ChannelTypePixverse] = taskpixverse.ModelList
+	channelId2Models[constant.ChannelTypeDoubaoVideo] = taskdoubao.ModelList
+	channelId2Models[constant.ChannelTypeBytePlusVideo] = taskbyteplus.ModelList
 	openAIModels = lo.UniqBy(openAIModels, func(m dto.OpenAIModels) string {
 		return m.Id
 	})


### PR DESCRIPTION
## Background

Follow-up to #59 (BytePlus 海外 Seedance channel). #59 was squash-merged
before this fix landed on its branch, so the fix was orphaned on the
now-closed `feat/seedance2-byteplus` branch and never reached `main`.
This PR re-applies it cleanly on top of current `main`.

## Problem

`controller/model.go::init()` builds the model list returned by
`GET /api/channel/models` — the data source for the channel-create
form's "Fill Related Models" button and custom-model autocomplete.
The APIType loop only covers chat-style adaptors (`GetAdaptor`).
Task-only channels reached via `GetTaskAdaptor` need explicit
per-package registration, exactly like the existing `taskpixverse`
lines.

Only Pixverse was registered. **Doubao and BytePlus Seedance were
both missing**, so an operator creating a `BytePlusVideo` channel on
production saw an empty suggestion list and could not find
`seedance-2.0-global` in the model picker. (Manual paste still works —
routing only reads the channel `models` field — but discovery was
broken; reported by an operator configuring production.)

## Fix

Register `taskdoubao.ModelList` and `taskbyteplus.ModelList` in both
`openAIModels` and `channelId2Models`, mirroring the existing
`taskpixverse` block. Doubao is folded in too since it had the
identical latent gap.

CLAUDE.md Rule 21 extended with step 4 documenting this registration
spot so the next task channel doesn't repeat it.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./controller/... ./relay/channel/task/doubao/...` green
- [x] Runtime: `GET /api/channel/models` (admin session) now returns
      `seedance-2.0-global`, `seedance-2.0-fast-global`, and
      `doubao-seedance-2-0-260128` (612 models total) — verified on the
      local container before the orphan was discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)