### PR TITLE
fix(pricing): correct Pixverse default vendor icon id

### DIFF
--- a/model/pricing_default.go
+++ b/model/pricing_default.go
@@ -63,7 +63,11 @@ var defaultVendorIcons = map[string]string{
 	"快手":         "Kling.Color",
 	"即梦":         "Jimeng.Color",
 	"Vidu":       "Vidu",
-	"Pixverse":   "Pixverse",
+	// Lobe icon id is PixVerse (capital V) + the .Color colored variant —
+	// the bare "Pixverse" string doesn't resolve and silently falls back
+	// to a one-letter avatar on /pricing. Mirrors the "字节跳动" →
+	// "Doubao.Color" convention above. See CLAUDE.md Rule 24.
+	"Pixverse":   "PixVerse.Color",
 	"微软":         "AzureAI",
 	"Microsoft":  "AzureAI",
 	"Azure":      "AzureAI",


### PR DESCRIPTION
## Problem

On `/pricing`, `pixverse-c1` and `pixverse-v6` show a one-letter "P"
fallback avatar instead of the PixVerse brand icon.

Root cause is a code-level seed typo:
`model/pricing_default.go::defaultVendorIcons["Pixverse"]` is the bare
string `"Pixverse"`, which is not a valid `@lobehub/icons` id. The
registry exports the icon as `PixVerse` (capital V) and the colored
variant requires the `.Color` suffix — same convention as the working
`"字节跳动": "Doubao.Color"` entry right above it.

`getOrCreateVendor` calls `getDefaultVendorIcon` and writes the broken
id onto every newly-created Pixverse vendor row, so the frontend's
`getLobeIcon` can't resolve it and falls back to the letter avatar.

## Fix

One-line map value change: `"Pixverse"` → `"PixVerse.Color"`.

## Operator note (important)

`getOrCreateVendor` only sets the icon when **creating** a vendor row —
it never updates an existing one. Deployments that already have a
Pixverse vendor row persisted with the bad icon need a one-time manual
correction:

```sql
UPDATE vendors SET icon = 'PixVerse.Color'
WHERE name = 'Pixverse' AND deleted_at IS NULL;
```

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./model/...` green
- [x] Verified earlier in dev: with the row carrying `PixVerse.Color`,
      pixverse-c1 / pixverse-v6 render the real PixVerse colored SVG on
      /pricing (3-child `<svg>`, no letter fallback).

Related: CLAUDE.md Rule 24 already documents that `vendors.icon` must be
a real Lobe Icon name; this fixes the one code default that violated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)