### PR TITLE
fix(imageaudit): propagate upstream 4xx + message; stop wrapping as 502

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,3 +451,21 @@ Invariants a future change can silently break:
 7. **A param dropped before it is logged is unrecoverable.** This subsystem is the standing forensic/refund answer; don't add drop-before-observe parse paths that bypass it (ties to Rule 29).
 
 Tests: `service/auditlog` (capBody bound, prepareBodies redact+clear, pre-init no-op), `middleware` (streaming passthrough + bounded tee, disabled no-op, skip-prefix). No DB fixtures — there is no DB.
+
+### Rule 31: Don't wrap upstream errors — propagate status and message
+
+Upstream provider errors (Ark, BytePlus, OpenAI, Claude, vendor adaptors, etc.) must surface to the gateway client with:
+
+- **Status code matched to fault location.** A 4xx from upstream is a 4xx to our client. A 5xx from upstream OR a transport-level failure is 502. Only synthesize 500 for true internal panics. Never default a `switch`/`default` branch to 502 — that's how every unhandled case becomes "gateway broken" in the client UI.
+- **Upstream's own message verbatim in the response body.** Truncate only for size (≤ 2KB raw body), mask only what `common.MaskSensitiveInfo` masks (URL hosts/paths). Never replace with a synthetic Chinese/English string like `"请求上游地址失败"` — the original wording (`"Width must be between 300px and 6000px."`) is what makes the error actionable.
+- **Use typed errors for upstream calls.** When adding a new vendor adaptor that issues HTTP calls, return a `*VendorUpstreamError{Action, HTTPStatus, Code, Message, RawBody}` from the call layer instead of `fmt.Errorf("vendor: HTTP %d: %s", ...)`. See `service/imageaudit/ark.go::ArkUpstreamError` for the canonical shape; downstream code uses `errors.As` + `IsClientFault()` to route correctly.
+
+**Why this matters operationally:** Cloudflare substitutes its own HTML "Bad gateway" page for any source 5xx, destroying the JSON body. So a 502 for a user-input error means the actionable message never reaches the customer; they see a generic CF page and retry deterministically — see the `seedvr2_upscaled_*.jpg` width-too-large incident.
+
+**Audit checklist when adding/editing a wrapper:**
+1. Does the wrapper ever synthesize a status code that wasn't on `err`? If yes, can it pick the wrong one?
+2. Does it drop information from `err.Error()` other than URL masking?
+3. Does its `default`/fallthrough branch produce 5xx for a user-input case?
+4. If the upstream is HTTP-based, do we preserve the upstream HTTP status somewhere reachable by `errors.As`?
+
+Known prior offenders fixed: `relay/image_audit_error.go`, `controller/image_audit.go`. Known unfixed: `service/error.go::ClaudeErrorWrapper` ("请求上游地址失败" replacement), `service/error.go::RelayErrorHandler` (`showBodyWhenFail=false` discards upstream body in 11 prod call sites), `relay/relay_task.go:236,242` (hardcoded 500 for BuildRequestBody / DoRequest). Fix incrementally; the rule is the gate for new code.

--- a/controller/image_audit.go
+++ b/controller/image_audit.go
@@ -55,6 +55,40 @@ func (r *imageAuditCreateRequest) imageSource() string {
 	return ""
 }
 
+// classifyImageAuditError maps an imageaudit/ARK error to the public HTTP
+// response shape. Default is 502 image_audit_error (gateway infra failure),
+// but two cases get more specific treatment:
+//
+//   - *imageaudit.ArkUpstreamError with IsClientFault()==true: forward as
+//     400 image_audit_rejected with the upstream's own Message verbatim, so
+//     the caller learns *why* (e.g. "Width must be between 300px and 6000px.")
+//     and so Cloudflare doesn't substitute its own HTML for our 5xx body.
+//   - Wait() poll-timeout: 504 image_audit_wait_timeout, matching the
+//     pre-rework behavior.
+func classifyImageAuditError(err error, base map[string]any) (int, string, string, map[string]any) {
+	extras := base
+	if extras == nil {
+		extras = map[string]any{}
+	}
+	var ark *imageaudit.ArkUpstreamError
+	if errors.As(err, &ark) && ark.IsClientFault() {
+		message := ark.MetaMsg
+		if message == "" {
+			message = ark.RawBody
+		}
+		upstream := map[string]any{"http": ark.HTTPStatus}
+		if ark.MetaCode != "" {
+			upstream["code"] = ark.MetaCode
+		}
+		extras["upstream"] = upstream
+		return http.StatusBadRequest, "image_audit_rejected", message, extras
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		return http.StatusGatewayTimeout, "image_audit_wait_timeout", err.Error(), extras
+	}
+	return http.StatusBadGateway, "image_audit_error", err.Error(), extras
+}
+
 // imageAuditError is the OpenAI-flavored error envelope. We use the
 // raw map (not types.OpenAIError) because we want the `failed_image`
 // metadata to be a structured object, not a JSON-encoded string.
@@ -111,7 +145,8 @@ func CreateImageAudit(c *gin.Context) {
 
 	rec, err := imageaudit.Submit(c.Request.Context(), src, userID, tokenID, req.Region)
 	if err != nil {
-		imageAuditError(c, http.StatusBadGateway, "image_audit_error", err.Error(), nil)
+		status, code, message, extras := classifyImageAuditError(err, nil)
+		imageAuditError(c, status, code, message, extras)
 		return
 	}
 
@@ -119,19 +154,11 @@ func CreateImageAudit(c *gin.Context) {
 		// Wait blocks until terminal or ARK_ASSETS_POLL_TIMEOUT.
 		updated, werr := imageaudit.Wait(c.Request.Context(), rec.RecordID)
 		if werr != nil && !errors.Is(werr, gorm.ErrRecordNotFound) {
-			// Wait returned the latest record we have; surface as a
-			// 504 if we hit timeout, otherwise 502.
-			status := http.StatusBadGateway
-			code := "image_audit_error"
-			if strings.Contains(werr.Error(), "timed out") {
-				status = http.StatusGatewayTimeout
-				code = "image_audit_wait_timeout"
-			}
 			if updated != nil {
 				rec = updated
 			}
-			imageAuditError(c, status, code, werr.Error(),
-				map[string]any{"record": rec})
+			status, code, message, extras := classifyImageAuditError(werr, map[string]any{"record": rec})
+			imageAuditError(c, status, code, message, extras)
 			return
 		}
 		if updated != nil {

--- a/relay/image_audit_error.go
+++ b/relay/image_audit_error.go
@@ -17,10 +17,18 @@ import (
 // taskErrorFromImageAuditError walks err's chain looking for a
 // *PerImageAuditError. When found, returns a TaskError with:
 //
-//   - Code: image_audit_failed (moderation rejection) or
-//     image_audit_error (infra failure)
-//   - StatusCode: 400 for moderation, 502 for infra
-//   - Data: { failed_image: {index, role, source, asset_id, reason} }
+//   - Code:
+//     image_audit_failed   — moderation verdict, 400
+//     image_audit_rejected — upstream 4xx (e.g. width > 6000px), 400
+//     image_audit_error    — true infra failure, 502
+//   - StatusCode: 4xx for caller-fixable cases, 502 only when we genuinely
+//     failed as a gateway. Status MUST be 4xx for upstream user-input
+//     rejections because Cloudflare substitutes its own HTML page for any
+//     source 5xx, hiding our JSON body (and the upstream's actionable hint).
+//   - Message: when the upstream returned a structured Code/Message, we use
+//     its Message verbatim so callers see "Width must be between 300px and
+//     6000px." rather than our wrapper chain.
+//   - Data: { failed_image: {...}, upstream: {code, http} }
 //
 // Source is truncated to a sane length (URL or short data URI tag) so
 // a multi-MB base64 input doesn't bloat the error response.
@@ -49,16 +57,40 @@ func taskErrorFromImageAuditError(err error) *dto.TaskError {
 
 	code := "image_audit_error"
 	status := http.StatusBadGateway
-	if imageaudit.IsAuditFailure(err) {
+	message := err.Error()
+
+	var ark *imageaudit.ArkUpstreamError
+	switch {
+	case imageaudit.IsAuditFailure(err):
 		code = "image_audit_failed"
 		status = http.StatusBadRequest
+	case errors.As(err, &ark) && ark.IsClientFault():
+		code = "image_audit_rejected"
+		status = http.StatusBadRequest
+		// Surface the upstream's own message verbatim; falling back to the
+		// truncated raw body keeps the caller informed even when Volcano
+		// returns an unparseable envelope.
+		if ark.MetaMsg != "" {
+			message = ark.MetaMsg
+		} else if ark.RawBody != "" {
+			message = ark.RawBody
+		}
+	}
+
+	data := map[string]any{"failed_image": failedImage}
+	if ark != nil {
+		upstream := map[string]any{"http": ark.HTTPStatus}
+		if ark.MetaCode != "" {
+			upstream["code"] = ark.MetaCode
+		}
+		data["upstream"] = upstream
 	}
 
 	return &dto.TaskError{
 		Code:       code,
-		Message:    err.Error(),
+		Message:    message,
 		StatusCode: status,
-		Data:       map[string]any{"failed_image": failedImage},
+		Data:       data,
 		Error:      err,
 		LocalError: true,
 	}

--- a/relay/image_audit_error_test.go
+++ b/relay/image_audit_error_test.go
@@ -1,0 +1,101 @@
+package relay
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/QuantumNous/new-api/service/imageaudit"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTaskErrorFromImageAuditError_ArkClientFault_PassesThrough4xxAndUpstreamMessage
+// guards Rule 31 / Issue #68-style regressions: when ARK rejects a caller's
+// reference image because the upstream validation fails (HTTP 4xx +
+// InvalidParameter.*), the gateway must surface a 4xx with the upstream's own
+// Message as the visible error, not a generic 502 + wrapper chain. CF
+// substitutes its own HTML for any source 5xx, so a 502 here would hide the
+// actionable hint from the caller.
+func TestTaskErrorFromImageAuditError_ArkClientFault_PassesThrough4xxAndUpstreamMessage(t *testing.T) {
+	ark := &imageaudit.ArkUpstreamError{
+		Action:     "CreateAsset",
+		HTTPStatus: http.StatusBadRequest,
+		MetaCode:   "InvalidParameter.WidthTooLarge",
+		MetaMsg:    "Width must be between 300px and 6000px.",
+		RawBody:    `{"ResponseMetadata":{"Error":{...}}}`,
+	}
+	// Mirror the production wrap chain: Submit wraps with fmt.Errorf %w and
+	// the relay layer wraps in *PerImageAuditError before reaching here.
+	wrapped := &imageaudit.PerImageAuditError{
+		Index:  0,
+		Role:   "reference_image",
+		Source: "https://example.r2.cloudflarestorage.com/seedvr2_upscaled.jpg",
+		Err:    fmt.Errorf("imageaudit: createAsset: %w", ark),
+	}
+
+	got := taskErrorFromImageAuditError(wrapped)
+	require.NotNil(t, got, "expected a TaskError, got nil")
+
+	assert.Equal(t, http.StatusBadRequest, got.StatusCode,
+		"upstream 4xx must propagate as 4xx, not 502 — CF eats 5xx bodies")
+	assert.Equal(t, "image_audit_rejected", got.Code)
+	assert.Equal(t, "Width must be between 300px and 6000px.", got.Message,
+		"caller must see the upstream's own message verbatim")
+
+	data, ok := got.Data.(map[string]any)
+	require.True(t, ok)
+	upstream, ok := data["upstream"].(map[string]any)
+	require.True(t, ok, "data.upstream should expose the upstream code/status")
+	assert.Equal(t, "InvalidParameter.WidthTooLarge", upstream["code"])
+	assert.Equal(t, http.StatusBadRequest, upstream["http"])
+
+	failedImage, ok := data["failed_image"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 0, failedImage["index"])
+	assert.Equal(t, "reference_image", failedImage["role"])
+}
+
+// TestTaskErrorFromImageAuditError_AuditFailure_Stays400 guards the existing
+// audit-moderation branch — a deterministic content-rejection from ARK must
+// still emit image_audit_failed + 400 (not the new image_audit_rejected).
+func TestTaskErrorFromImageAuditError_AuditFailure_Stays400(t *testing.T) {
+	wrapped := &imageaudit.PerImageAuditError{
+		Index:  1,
+		Role:   "first_frame",
+		Source: "https://x/y.jpg",
+		Err:    &imageaudit.AuditError{AssetId: "asset-abc", Status: "Failed", Reason: "policy_violation"},
+	}
+	got := taskErrorFromImageAuditError(wrapped)
+	require.NotNil(t, got)
+
+	assert.Equal(t, http.StatusBadRequest, got.StatusCode)
+	assert.Equal(t, "image_audit_failed", got.Code)
+}
+
+// TestTaskErrorFromImageAuditError_InfraFailure_Stays502 guards that a
+// non-typed, non-AuditError chain still falls into the 502 default — that's
+// the legitimate "we are the gateway and we genuinely failed" case (network
+// error talking to ARK, panic, etc.).
+func TestTaskErrorFromImageAuditError_InfraFailure_Stays502(t *testing.T) {
+	wrapped := &imageaudit.PerImageAuditError{
+		Index:  0,
+		Source: "https://x/y.jpg",
+		Err:    errors.New("dial tcp: connection refused"),
+	}
+	got := taskErrorFromImageAuditError(wrapped)
+	require.NotNil(t, got)
+
+	assert.Equal(t, http.StatusBadGateway, got.StatusCode)
+	assert.Equal(t, "image_audit_error", got.Code)
+}
+
+// TestTaskErrorFromImageAuditError_NonImageAuditError_ReturnsNil keeps the
+// caller-side fallback intact — callers (relay_task.go) only switch into the
+// per-image envelope when this function returns non-nil; an arbitrary error
+// must continue to fall through to the generic build_request_failed wrapper.
+func TestTaskErrorFromImageAuditError_NonImageAuditError_ReturnsNil(t *testing.T) {
+	assert.Nil(t, taskErrorFromImageAuditError(errors.New("some other error")))
+}

--- a/service/imageaudit/ark.go
+++ b/service/imageaudit/ark.go
@@ -39,6 +39,42 @@ const (
 	arkRequestTimeout = 30 * time.Second
 )
 
+// ArkUpstreamError carries the structured error returned by an Ark / BytePlus
+// ModelArk control-plane call. Distinct from a generic Go error so the relay
+// and controller layers can route upstream 4xx responses back to the caller
+// as 4xx — i.e. with the upstream's own message visible — instead of folding
+// them into a generic 502 envelope (whose body Cloudflare then replaces with
+// its own HTML page, hiding the actionable upstream hint).
+//
+// HTTPStatus is 0 for transport-level failures (DNS, dial). MetaCode/MetaMsg
+// come from the standard ResponseMetadata.Error envelope; they are empty when
+// the response body is unparseable, in which case RawBody is the fallback.
+type ArkUpstreamError struct {
+	Action     string
+	HTTPStatus int
+	MetaCode   string
+	MetaMsg    string
+	RawBody    string
+}
+
+func (e *ArkUpstreamError) Error() string {
+	if e.MetaMsg != "" {
+		if e.MetaCode != "" {
+			return fmt.Sprintf("ark.%s: HTTP %d %s: %s", e.Action, e.HTTPStatus, e.MetaCode, e.MetaMsg)
+		}
+		return fmt.Sprintf("ark.%s: HTTP %d: %s", e.Action, e.HTTPStatus, e.MetaMsg)
+	}
+	return fmt.Sprintf("ark.%s: HTTP %d: %s", e.Action, e.HTTPStatus, e.RawBody)
+}
+
+// IsClientFault reports whether the upstream rejected our request because of
+// caller-supplied input (e.g. invalid image dimensions, malformed URL). A 4xx
+// here must surface to the gateway client as 4xx so the message survives the
+// CF 5xx HTML substitution and so the client sees something actionable.
+func (e *ArkUpstreamError) IsClientFault() bool {
+	return e.HTTPStatus >= 400 && e.HTTPStatus < 500
+}
+
 // arkResponse is the common envelope for every Assets call.
 type arkResponse struct {
 	ResponseMetadata struct {
@@ -120,20 +156,36 @@ func (c *arkClient) callAction(ctx context.Context, action string, body, out any
 	if err != nil {
 		return fmt.Errorf("ark.%s: read body: %w", action, err)
 	}
+	// Volcano returns the standard envelope (with ResponseMetadata.Error
+	// populated) even for HTTP 4xx, so parse first and let the typed error
+	// carry whatever structure is available.
+	var env arkResponse
+	envOK := json.Unmarshal(respBody, &env) == nil
+
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("ark.%s: HTTP %d: %s", action, resp.StatusCode, truncate(string(respBody), 500))
+		e := &ArkUpstreamError{
+			Action:     action,
+			HTTPStatus: resp.StatusCode,
+			RawBody:    truncate(string(respBody), 2000),
+		}
+		if envOK && env.ResponseMetadata.Error != nil {
+			e.MetaCode = env.ResponseMetadata.Error.Code
+			e.MetaMsg = env.ResponseMetadata.Error.Message
+		}
+		return e
 	}
 
-	var env arkResponse
-	if err := json.Unmarshal(respBody, &env); err != nil {
-		return fmt.Errorf("ark.%s: unmarshal envelope: %w; body=%s", action, err, truncate(string(respBody), 500))
+	if !envOK {
+		return fmt.Errorf("ark.%s: unmarshal envelope; body=%s", action, truncate(string(respBody), 500))
 	}
 	if env.ResponseMetadata.Error != nil {
-		return fmt.Errorf("ark.%s: %s — %s",
-			action,
-			env.ResponseMetadata.Error.Code,
-			env.ResponseMetadata.Error.Message,
-		)
+		return &ArkUpstreamError{
+			Action:     action,
+			HTTPStatus: resp.StatusCode,
+			MetaCode:   env.ResponseMetadata.Error.Code,
+			MetaMsg:    env.ResponseMetadata.Error.Message,
+			RawBody:    truncate(string(respBody), 2000),
+		}
 	}
 	if out == nil || len(env.Result) == 0 {
 		return nil

--- a/service/imageaudit/ark_test.go
+++ b/service/imageaudit/ark_test.go
@@ -1,0 +1,117 @@
+// ark_test.go — unit tests for callAction's error classification.
+//
+// The full ARK round-trip is covered by the container e2e test; here we
+// only verify that an HTTP 4xx response from the control plane comes back
+// as a typed *ArkUpstreamError with the upstream's Message intact, so the
+// relay/controller layer can forward it as a 4xx to the gateway client.
+package imageaudit
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reproduces the literal upstream payload from the SeedVR2 super-resolution
+// reference-image bug — width > 6000px is the exact case that motivated the
+// typed-error rework. Region/Action/Code/Message copied verbatim.
+const widthTooLargeBody = `{"ResponseMetadata":{"RequestId":"202605282340389F859187A1D355E500AD","Action":"CreateAsset","Version":"2024-01-01","Service":"ark","Region":"ap-southeast-1","Error":{"Code":"InvalidParameter.WidthTooLarge","Message":"Width must be between 300px and 6000px.","Data":null}}}`
+
+// newTestArkClient wires callAction's hardcoded https://<host>/ URL through
+// the httptest.NewTLSServer's self-signed certificate. We don't care about
+// signature verification on the receiving side; the server returns whatever
+// status/body the test specifies.
+func newTestArkClient(t *testing.T, srv *httptest.Server) *arkClient {
+	t.Helper()
+	host := strings.TrimPrefix(srv.URL, "https://")
+	return &arkClient{
+		resolved: Resolved{
+			Ak:      "test-ak",
+			Sk:      "test-sk",
+			Host:    host,
+			Region:  "ap-southeast-1",
+			Service: "ark",
+			Project: "tianwenyue-6",
+		},
+		hc: srv.Client(),
+	}
+}
+
+func TestCallAction_HTTP400_ReturnsTypedUpstreamError(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(widthTooLargeBody))
+	}))
+	defer srv.Close()
+
+	c := newTestArkClient(t, srv)
+	err := c.callAction(context.Background(), "CreateAsset",
+		map[string]any{"GroupId": "g1", "URL": "https://example.com/x.jpg", "AssetType": "Image"}, nil)
+	require.Error(t, err)
+
+	var ark *ArkUpstreamError
+	require.True(t, errors.As(err, &ark), "expected *ArkUpstreamError; got %T: %v", err, err)
+	assert.Equal(t, http.StatusBadRequest, ark.HTTPStatus)
+	assert.Equal(t, "CreateAsset", ark.Action)
+	assert.Equal(t, "InvalidParameter.WidthTooLarge", ark.MetaCode)
+	assert.Equal(t, "Width must be between 300px and 6000px.", ark.MetaMsg)
+	assert.True(t, ark.IsClientFault(), "HTTP 400 must be classified as client fault")
+	assert.Contains(t, ark.RawBody, "WidthTooLarge", "raw body retained for diagnostics")
+}
+
+func TestCallAction_HTTP500_NotClientFault(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"ResponseMetadata":{"Error":{"Code":"InternalError","Message":"boom"}}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestArkClient(t, srv)
+	err := c.callAction(context.Background(), "CreateAsset", map[string]any{}, nil)
+	require.Error(t, err)
+
+	var ark *ArkUpstreamError
+	require.True(t, errors.As(err, &ark))
+	assert.Equal(t, http.StatusInternalServerError, ark.HTTPStatus)
+	assert.False(t, ark.IsClientFault(), "HTTP 5xx must NOT be classified as client fault")
+}
+
+func TestCallAction_HTTP200WithEnvelopeError_ReturnsTypedUpstreamError(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ResponseMetadata":{"Error":{"Code":"SomeCode","Message":"some msg"}}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestArkClient(t, srv)
+	err := c.callAction(context.Background(), "CreateAsset", map[string]any{}, nil)
+	require.Error(t, err)
+
+	var ark *ArkUpstreamError
+	require.True(t, errors.As(err, &ark))
+	assert.Equal(t, http.StatusOK, ark.HTTPStatus)
+	assert.Equal(t, "SomeCode", ark.MetaCode)
+	assert.Equal(t, "some msg", ark.MetaMsg)
+	assert.False(t, ark.IsClientFault(), "HTTP 200 with envelope error is NOT client fault")
+}
+
+func TestArkUpstreamError_Error_FormatsAllFields(t *testing.T) {
+	e := &ArkUpstreamError{
+		Action:     "CreateAsset",
+		HTTPStatus: 400,
+		MetaCode:   "InvalidParameter.WidthTooLarge",
+		MetaMsg:    "Width must be between 300px and 6000px.",
+	}
+	got := e.Error()
+	assert.Contains(t, got, "CreateAsset")
+	assert.Contains(t, got, "400")
+	assert.Contains(t, got, "InvalidParameter.WidthTooLarge")
+	assert.Contains(t, got, "Width must be between 300px and 6000px.")
+}


### PR DESCRIPTION
## Summary

- ARK rejected a customer's request with `HTTP 400 InvalidParameter.WidthTooLarge: Width must be between 300px and 6000px.`; we folded it into a generic 502 `image_audit_error`, Cloudflare swapped the JSON body for its own HTML page, and the downstream client (Syncast) retried the same oversized image 12× because the actionable hint never reached them.
- New typed `*ArkUpstreamError` carries `HTTPStatus / MetaCode / MetaMsg / RawBody`; both the relay path (`/v1/video/generations` with `metadata.audit_image=true`) and the public `/v1/image-audits` controller now forward upstream 4xx as 4xx with the upstream's own message verbatim.
- New CLAUDE.md Rule 31 codifies the "don't wrap, propagate" principle so the next vendor adaptor doesn't repeat the trap. Inventory of remaining offenders (`ClaudeErrorWrapper`'s 请求上游地址失败 replacement, `RelayErrorHandler showBodyWhenFail=false`, the hardcoded 500s in `relay_task.go`) listed in the rule body for incremental follow-up.

### Customer-visible behavior change

| Before | After |
|---|---|
| `502` + CF HTML page | `400` + `{"code":"image_audit_rejected","message":"Width must be between 300px and 6000px.","data":{"failed_image":{...},"upstream":{"code":"InvalidParameter.WidthTooLarge","http":400}}}` |
| Audit moderation reject: `400 image_audit_failed` (unchanged) | unchanged |
| Genuine infra failure (transport / panic): `502 image_audit_error` (unchanged) | unchanged |

## Test plan

- [x] `go test ./service/imageaudit/ ./relay/ ./controller/ -count=1` (all pass)
- [x] `TestCallAction_HTTP400_ReturnsTypedUpstreamError` covers the literal `widthTooLargeBody` payload from the audit log
- [x] `TestTaskErrorFromImageAuditError_ArkClientFault_PassesThrough4xxAndUpstreamMessage` asserts caller sees the upstream message and a 4xx
- [x] Existing audit-moderation (`image_audit_failed`) and infra-failure (`image_audit_error`) branches covered by separate cases
- [ ] Manual: rebuild container, submit a `metadata.audit_image=true` task with a > 6000px reference image, confirm response is JSON 400 (not CF HTML) — to be done post-merge against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)